### PR TITLE
📙 [just] check for Copilot and Claude reviews

### DIFF
--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -27,12 +27,14 @@ pr: _has_commits && pr_checks
 
     bodyfile=$(mktemp /tmp/justfile.XXXXXX)
 
-    echo "## Done:" >> $bodyfile
+    echo "## Done" >> $bodyfile
     echo "" >> $bodyfile
     echo "- {{ last_commit_message }}" >> $bodyfile
     echo "" >> $bodyfile
     echo "" >> $bodyfile
-    echo "(Automated in \`justfile\`.)" >> $bodyfile
+    echo "## Meta" >> $bodyfile
+    echo "" >> $bodyfile
+    echo "(Automated in \`.just/gh-process.just\`.)" >> $bodyfile
 
     echo ''
     cat "$bodyfile"


### PR DESCRIPTION
## Context 🌍 

I've been annoyed with missing Copilot reviews while working in a terminal-focused development workflow.  I [asked in the github cli repo](https://github.com/cli/cli/issues/11747) about this problem and I was amazed to get an [awesome answer with exactly what I needed](https://github.com/cli/cli/issues/11747#issuecomment-3402291656)

## Done ✅ 

Created a new subcommand `just pr_chesk` which watches for the Github Actions to finish running and then it checks for Copilot code reviews and then it checks for Claude code reviews.

## Trust but Verify :tm:

I developed this in one repo, verified and refined it in a private repo and so this PR is the third one that has used this code happily.  I've also run the new subcommand separately quite a few times.

## Meta 🖥️ 

It is time for a new meta...

(Automated in `just/gh-process.just`.)
