### PR TITLE
😮 [just] verify v3.5 and quote more consistently

### DIFF
--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -8,7 +8,7 @@ release_branch := "main"
 # escape from branch, back to starting point
 [group('Process')]
 sync:
-    git checkout {{ release_branch }}
+    git checkout "{{ release_branch }}"
     git pull
     git stp
 


### PR DESCRIPTION
## Context

#30 could not verify itself, so this PR was created based on a new branch with two commits.

## Done

- 😮 [just] verify v3.5 and quote more consistently
- bump to v3.6


## Meta

(Automated in `.just/gh-process.just`.)
