### PR TITLE
🟣 [just] shellcheck has purple headings

### DIFF
--- a/.just/shellcheck.just
+++ b/.just/shellcheck.just
@@ -127,7 +127,7 @@ shellcheck:
     ISSUES_FOUND=$(cat "$ISSUES_FILE")
 
     echo ""
-    echo "{{BLUE}}Checked $SCRIPTS_CHECKED shell scripts{{NORMAL}}"
+    echo "{{MAGENTA}}Checked $SCRIPTS_CHECKED shell scripts{{NORMAL}}"
 
     if [[ $ISSUES_FOUND -eq 0 ]]; then
         echo "{{GREEN}}No shellcheck issues found!{{NORMAL}}"


### PR DESCRIPTION
## Done

- 🟣 [just] shellcheck has purple headings


## Meta

(Automated in `.just/gh-process.just`.)
