### PR TITLE
💊 [just] release notes cleanup and v5.9 documented

### DIFF
--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-04-19T17:24:27Z",
+  "generated_at": "2026-04-23T17:12:23Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -146,9 +146,9 @@
 ]},
     ".just/gh-process.just": {"versions": [
         {
-          "checksum": "233a857a1d52e1fee965d4cc8f23cba0716d49b98fdd8964adfcdbbe732b0e4d",
-          "commit": "566b82af7f987194f92fa6a3191ff0531988e883",
-          "date": "2026-04-19T10:23:10-07:00",
+          "checksum": "478383a2ef0c73ce1d5b6b8686bfdd1640458b6777f19f666ec51b490d546bbe",
+          "commit": "b853d0eeecf7ce83e501c9e2ba129547577bf186",
+          "date": "2026-04-19T10:29:45-07:00",
           "version": "",
           "is_latest": true
         }

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -23,7 +23,7 @@ running it, all scripts are immediately usable without additional steps.
 
 ### v5.8 - CRLF-Resilient PR Body Updates (2026-03-21)
 
-**Related PR:** [#107](https://github.com/fini-net/template-repo/pull/107)
+- **Related PR:** [#107](https://github.com/fini-net/template-repo/pull/107)
 
 Fixed a bug where `pr_update` would silently fail or produce corrupted output
 when the PR body contained Windows-style CRLF line endings. GitHub's API
@@ -65,7 +65,7 @@ Utilize the [gh observer extension](https://github.com/fini-net/gh-observer) if 
 
 ### v5.6 - Release Version Validation (2026-01-30)
 
-**Related PR:** [#92](https://github.com/fini-net/template-repo/pull/92)
+- **Related PR:** [#92](https://github.com/fini-net/template-repo/pull/92)
 
 Added version format validation to the `release` recipe to prevent accidental releases with malformed version numbers. Previously, you could run `just release anything` and it would attempt to create a GitHub release with whatever string you provided, potentially creating confusing or invalid release tags.
 
@@ -86,8 +86,8 @@ This change makes the release workflow safer by catching version format errors u
 
 ### v5.5 - Robust Copilot Suggestion Application (2026-01-28)
 
-Fixes issue [#76](https://github.com/fini-net/template-repo/issues/76)
-**Related PR:** [#88](https://github.com/fini-net/template-repo/pull/88)
+- Fixes issue [#76](https://github.com/fini-net/template-repo/issues/76)
+- **Related PR:** [#88](https://github.com/fini-net/template-repo/pull/88)
 
 Enhanced the `copilot_pick` recipe with the ability to directly apply Copilot suggestions, plus comprehensive safety improvements based on Claude Code review feedback. Previously, `copilot_pick` was read-only - you could view suggestions but had to manually apply them. Now you can apply suggestions directly with proper backup and rollback capabilities.
 
@@ -127,8 +127,8 @@ The feature makes Copilot suggestions much more actionable while maintaining the
 
 ### v5.3 - Configurable Release Workflow (2026-01-28)
 
-Fixes issue [#82](https://github.com/fini-net/template-repo/issues/82)
-**Related PR:** [#84](https://github.com/fini-net/template-repo/pull/84)
+- Fixes issue [#82](https://github.com/fini-net/template-repo/issues/82)
+- **Related PR:** [#84](https://github.com/fini-net/template-repo/pull/84)
 
 Added the `standard-release` flag to `.repo.toml` that allows projects to disable the default release recipes when they need custom release mechanisms. Previously, all repos inherited the standard `release` and `release_age` recipes whether they needed them or not, which could cause confusion in projects with specialized release workflows.
 
@@ -151,8 +151,8 @@ This allows template-repo to serve both simple projects that want the standard r
 
 ### v5.2 - Template Sync System (2026-01-27)
 
-Fixes issue [#55](https://github.com/fini-net/template-repo/issues/55)
-**Related PR:** [#83](https://github.com/fini-net/template-repo/pull/83)
+- Fixes issue [#55](https://github.com/fini-net/template-repo/issues/55)
+- **Related PR:** [#83](https://github.com/fini-net/template-repo/pull/83)
 
 Implemented a safe update mechanism that allows derived repos to pull changes from template-repo while preserving local customizations.
 
@@ -189,8 +189,8 @@ Implemented a safe update mechanism that allows derived repos to pull changes fr
 
 Add `copilot_refresh` recipe to request new Copilot reviews on demand.
 
-**Fixes issue:** [#77](https://github.com/fini-net/template-repo/issues/77)
-**Related PR:** [#79](https://github.com/fini-net/template-repo/pull/79)
+- **Fixes issue:** [#77](https://github.com/fini-net/template-repo/issues/77)
+- **Related PR:** [#79](https://github.com/fini-net/template-repo/pull/79)
 
 - **copilot_refresh recipe** - Request a fresh Copilot review on current PR
   - Uses GitHub REST API to add copilot-pull-request-reviewer[bot] as reviewer
@@ -265,15 +265,15 @@ updates.
 
 ### v4.9 - Copilot Suggestion Count
 
+- **Fixes issue:** [#73](https://github.com/fini-net/template-repo/issues/73)
+- **Related PR:** [#74](https://github.com/fini-net/template-repo/pull/74)
+
 Enhanced the Copilot review display to show a count of suggestions instead of
 raw JSON output, making it easier to quickly assess how many items need attention.
 Previously, after PR checks completed, you'd see the full JSON dump of all Copilot
 suggestions, which was hard to scan at a glance. Now you get a clear summary of
 how many suggestions there are, and the count appears both immediately after checks
 and at the end of Claude's review output.
-
-**Fixes issue:** [#73](https://github.com/fini-net/template-repo/issues/73)
-**Related PR:** [#74](https://github.com/fini-net/template-repo/pull/74)
 
 - **Count display** - Shows "Total Copilot suggestions: N" after PR checks complete,
   or "No Copilot suggestions - looks good!" when clean. Replaces the immediate
@@ -299,6 +299,9 @@ Pairs nicely with the `copilot_pick` recipe from v4.8 for diving into specific
 suggestions when needed.
 
 ### v4.8 - Copilot Suggestion Picker
+
+- **Fixes issue:** [#67](https://github.com/fini-net/template-repo/issues/67)
+- **Related PR:** [#72](https://github.com/fini-net/template-repo/pull/72)
 
 Added an interactive picker for browsing and viewing GitHub Copilot PR review
 suggestions without leaving the terminal. Previously, you could see a JSON dump
@@ -334,10 +337,10 @@ opening the PR in a browser - perfect for quickly reviewing specific Copilot
 suggestions while staying in your terminal workflow. Exit gracefully with
 Ctrl+C if you don't want to view any suggestions.
 
-**Fixes issue:** [#67](https://github.com/fini-net/template-repo/issues/67)
-**Related PR:** [#72](https://github.com/fini-net/template-repo/pull/72)
-
 ### v4.6 - Conditional AI Review Display
+
+- **Fixes issue:** [#63](https://github.com/fini-net/template-repo/issues/63)
+- **Related PR:** [#64](https://github.com/fini-net/template-repo/pull/64)
 
 Added repository metadata extraction system that enables flag-based conditional
 display of AI code reviews. Previously, Copilot and Claude reviews were always
@@ -366,10 +369,10 @@ on demand. This architecture enables future recipes to access repository metadat
 without parsing overhead, and provides a clean pattern for flag-based feature
 toggles across the workflow.
 
-**Fixes issue:** [#63](https://github.com/fini-net/template-repo/issues/63)
-**Related PR:** [#64](https://github.com/fini-net/template-repo/pull/64)
-
 ### v4.7 - Stale Review Detection
+
+- **Fixes issue:** [#69](https://github.com/fini-net/template-repo/issues/69)
+- **Related PR:** [#70](https://github.com/fini-net/template-repo/pull/70)
 
 Enhanced the `claude_review` recipe to detect and warn when Claude's PR review
 feedback doesn't apply to the latest code. Previously, the recipe would blindly
@@ -410,10 +413,10 @@ you're looking at fresh feedback or outdated suggestions. Particularly useful
 during rapid iteration when you're pushing frequent commits and want to know if
 you should wait for a new review.
 
-**Fixes issue:** [#69](https://github.com/fini-net/template-repo/issues/69)
-**Related PR:** [#70](https://github.com/fini-net/template-repo/pull/70)
-
 ### v4.5 - Smart Polling for PR Checks
+
+- **Fixes issue:** [#60](https://github.com/fini-net/template-repo/issues/60)
+- **Related PR:** [#61](https://github.com/fini-net/template-repo/pull/61)
 
 Replaced the fixed 8-second sleep in the `pr` recipe with an intelligent polling
 loop that waits for GitHub checks to actually start running. Previously, we'd
@@ -435,12 +438,11 @@ subshell context. Uses colored output (GREEN for success, YELLOW for timeout) an
 the `USING_GUM` environment variable to conditionally show progress indicators
 based on available tooling.
 
-**Fixes issue:** [#60](https://github.com/fini-net/template-repo/issues/60)
-**Related PR:** [#61](https://github.com/fini-net/template-repo/pull/61)
-
 ## December 2025 - Finer refinements
 
 ### v4.4 - PR Update Blank Line Preservation
+
+- **Related PR:** [#50](https://github.com/fini-net/template-repo/pull/50)
 
 Fixed a bug in the `pr_update` recipe where blank lines after the Done section
 were being incorrectly removed. The AWK script that preserves sections after
@@ -455,8 +457,6 @@ even after transitioning to the "after done" state.
 The fix ensures that when `pr_update` regenerates the Done section with current
 commits, it maintains proper markdown formatting with blank lines separating
 different sections of the PR description.
-
-**Related PR:** [#50](https://github.com/fini-net/template-repo/pull/50)
 
 ### v4.3 - Release Tag Visibility
 
@@ -476,6 +476,8 @@ away without extra steps.
 
 ### v4.2 - Prerequisites Installation Script
 
+- **Related PR:** [#48](https://github.com/fini-net/template-repo/pull/48)
+
 Added a standalone shell script to automate installation and verification of all
 prerequisites needed to run the just recipes in this repository:
 
@@ -493,9 +495,9 @@ friendly user experience with color-coded output and helpful error messages.
 Run `./.just/lib/install-prerequisites.sh` to check your environment or install
 missing tools.
 
-**Related PR:** [#48](https://github.com/fini-net/template-repo/pull/48)
-
 ### v4.1 - Release Monitoring and Iteration Workflow
+
+- **Related PR:** [#46](https://github.com/fini-net/template-repo/pull/46)
 
 Added three new recipes to improve release management and iterative PR workflows:
 
@@ -523,11 +525,11 @@ These recipes improve different phases of the development cycle - `release_age`
 for project maintenance awareness, `claude_review` for quick feedback access,
 and `again` for rapid PR iteration.
 
-**Related PR:** [#46](https://github.com/fini-net/template-repo/pull/46)
-
 ## November 2025 - The Polish Updates
 
 ### v4.0 - PR Description Management
+
+- **Related PR:** [#44](https://github.com/fini-net/template-repo/pull/44)
 
 Added two new recipes for managing pull request descriptions dynamically:
 
@@ -555,9 +557,9 @@ Other improvements in this release:
 - Initialize awk variables properly to avoid undefined behavior
 - Updated documentation to show new recipes
 
-**Related PR:** [#44](https://github.com/fini-net/template-repo/pull/44)
-
 ### v3.9 - Shellcheck Error Fixes
+
+- **Related PR:** [#40](https://github.com/fini-net/template-repo/pull/40)
 
 Before adding the shellcheck tooling in v3.8bis, we knew there were a bunch of
 shellcheck warnings in the gh-process module itself. This release fixes all
@@ -566,9 +568,9 @@ other shellcheck best practices. Nothing user-facing changed, but the code is
 now cleaner and more robust. This should also mean that our future AI code
 reviews will have less trivial stuff to complain about.
 
-**Related PR:** [#40](https://github.com/fini-net/template-repo/pull/40)
-
 ### v3.8bis - Shellcheck Integration
+
+- **Related PRs:** [#37](https://github.com/fini-net/template-repo/pull/37), [#39](https://github.com/fini-net/template-repo/pull/39)
 
 Added a whole new module for linting bash scripts embedded in just recipes.
 The `shellcheck` recipe extracts bash scripts from all justfiles in the repo,
@@ -583,9 +585,9 @@ meta - using just to check just recipes.
 
 This immediately found issues in our own code, which led to v3.9.
 
-**Related PRs:** [#37](https://github.com/fini-net/template-repo/pull/37), [#39](https://github.com/fini-net/template-repo/pull/39)
-
 ### v3.8 - Git Alias Expansion
+
+- **Related PR:** [#35](https://github.com/fini-net/template-repo/pull/35)
 
 Expanded all git aliases to use standard git commands, making this justfile
 work for everyone without requiring custom git configuration. Previously,
@@ -599,9 +601,9 @@ this workflow. Now it just works out of the box.
 Added inline comments showing the old alias names for reference, so if you're
 used to seeing `stp` in the output, you know what's happening.
 
-**Related PR:** [#35](https://github.com/fini-net/template-repo/pull/35)
-
 ### v3.7 - Pre-PR Hook Support
+
+- **Related PRs:** [#32](https://github.com/fini-net/template-repo/pull/32), [#33](https://github.com/fini-net/template-repo/pull/33)
 
 Added support for optional pre-PR hooks to allow project-specific automation
 before creating pull requests. The `pr` recipe now checks for
@@ -612,17 +614,17 @@ projects that need to rebuild assets (like Hugo sites) before pushing.
 - Hidden `_pr-hook` recipe (internal use)
 - Updated documentation with workflow versioning
 
-**Related PRs:** [#32](https://github.com/fini-net/template-repo/pull/32), [#33](https://github.com/fini-net/template-repo/pull/33)
-
 ### v3.6 - Quote Consistency
+
+- **Related PR:** [#31](https://github.com/fini-net/template-repo/pull/31)
 
 Improved shell script robustness with more consistent quoting of variables and
 just template parameters. Small change, but makes the scripts more reliable
 when dealing with branch names or paths that might contain spaces.
 
-**Related PR:** [#31](https://github.com/fini-net/template-repo/pull/31)
-
 ### v3.5 - Spacing and Multi-Commit Handling
+
+- **Related PR:** [#30](https://github.com/fini-net/template-repo/pull/30)
 
 Cleaned up the codebase and improved handling of branches with multiple commits:
 
@@ -631,20 +633,20 @@ Cleaned up the codebase and improved handling of branches with multiple commits:
 - Improved quoting of just variables
 - More consistent handling of multiple commits on a branch
 
-**Related PR:** [#30](https://github.com/fini-net/template-repo/pull/30)
-
 ## October 2025 - The AI Review Update
 
 ### v3.4 - Graceful Failure Handling
+
+- **Related PR:** [#26](https://github.com/fini-net/template-repo/pull/26)
 
 Fixed an issue where broken GitHub Actions would prevent the review comments
 from being displayed. The workflow now continues to show AI reviews even if
 some checks fail, because you probably want to see those reviews even more when
 things are broken.
 
-**Related PR:** [#26](https://github.com/fini-net/template-repo/pull/26)
-
 ### v3.3 - Copilot and Claude Review Integration
+
+- **Related PR:** [#25](https://github.com/fini-net/template-repo/pull/25)
 
 This was a big one. After PR checks complete, the workflow now automatically
 fetches and displays comments from both GitHub Copilot and Claude Code reviews
@@ -656,11 +658,11 @@ think.
 - Shows Claude's most recent comment
 - Uses `jq` to parse and filter review data
 
-**Related PR:** [#25](https://github.com/fini-net/template-repo/pull/25)
-
 ## August 2025 - The Safety Update
 
 ### v3.2 - Commit Verification
+
+- **Related PR:** [#21](https://github.com/fini-net/template-repo/pull/21)
 
 Added a sanity check to prevent accidentally creating empty PRs. The `pr` recipe now verifies that your branch actually has commits before allowing you to create a pull request. Uses `git cherry` to compare against the release branch.
 
@@ -668,17 +670,17 @@ Added a sanity check to prevent accidentally creating empty PRs. The `pr` recipe
 - Clear error message when branch is empty
 - Exit code 101 for tracking
 
-**Related PR:** [#21](https://github.com/fini-net/template-repo/pull/21)
-
 ### Faster PR Check Monitoring
 
-Changed the PR checks watcher to poll every 5 seconds instead of the default. Because who wants to wait around? GitHub's API might be lazy, but we don't have to be.
+- **Related PR:** [#20](https://github.com/fini-net/template-repo/pull/20)
 
-**Related PR:** [#20](https://github.com/fini-net/template-repo/pull/20)
+Changed the PR checks watcher to poll every 5 seconds instead of the default. Because who wants to wait around? GitHub's API might be lazy, but we don't have to be.
 
 ## June 2025 - The Beginning of this file
 
 ### v3.1 - Initial Release
+
+- **Related PR:** [#11](https://github.com/fini-net/template-repo/pull/11)
 
 Created as part of a larger refactoring effort to modularize the main justfile.
 This file extracted all the Git/GitHub workflow automation into a separate
@@ -697,8 +699,6 @@ Core recipes included from day one:
 Plus a bunch of sanity check helpers (`_on_a_branch`, `_main_branch`, etc.) to
 keep you from footgunning yourself.
 
-**Related PR:** [#11](https://github.com/fini-net/template-repo/pull/11)
-
 ---
 
 ## Pre-history
@@ -709,4 +709,4 @@ and some of my other repos, primarily
 [www-chicks-net](https://github.com/chicks-net/www-chicks-net/blob/main/justfile).
 It all started [very simply](https://github.com/chicks-net/www-chicks-net/commit/06f28b13d82e445951b10af1a57488a1dc9e1069).
 
-I think there were some 2.x versions, but I haven't found them again.
+I think there were some 2.x versions, but I haven't rediscovered them.

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -2,6 +2,38 @@
 
 This file tracks the evolution of the Git/GitHub workflow automation module.
 
+## April 2026 - Guard rails
+
+### v5.9 - PR Checks Requires Active Pull Request (2026-04-19)
+
+- Fixes issue [#115](https://github.com/fini-net/template-repo/issues/115)
+- **Fix PR:** [#122](https://github.com/fini-net/template-repo/pull/122)
+- **Regression PR:** [#97](https://github.com/fini-net/template-repo/pull/97)
+
+Added a sanity check to `pr_checks` requiring that you're on a branch with an
+active pull request before attempting to watch checks or display AI reviews.
+Previously, running `pr_checks` outside of PR context would fail with cryptic
+errors from `gh` commands that expect a PR association. Now it fails early with
+a clear message, consistent with other recipes like `pr_update` and `pr_verify`
+that already had this guard.
+
+- **Dependency change** - `pr_checks` now depends on `_on_a_pull_request` instead
+  of running unconditionally
+- **Consistent behavior** - Matches the pattern used by other PR-dependent recipes
+
+This was a regression that slipped in during v5.7. The history of the
+`_on_a_pull_request` guard on `pr_checks`:
+
+- **v4.0–v4.4** — `pr_checks: _on_a_pull_request` (direct dependency, added in #44)
+- **v4.5–v5.2** — `pr_checks: _wait_for_checks && claude_review` — the guard was
+  inherited transitively through `_wait_for_checks: _on_a_pull_request`
+- **v5.7** — [#97](https://github.com/fini-net/template-repo/pull/97) changed
+  to `pr_checks: && claude_review` — `_wait_for_checks` was moved from a
+  dependency to an inline fallback (the `gh observer` feature), which
+  accidentally dropped the `_on_a_pull_request` guard that came transitively
+  through it.
+- **v5.9** — Restored `_on_a_pull_request` directly
+
 ## March 2026 - More resilience
 
 ### v5.8.1 - Executable permissions for template updates (2026-03-22)
@@ -58,6 +90,8 @@ normal LF line endings.
 ## February 2026 - Learn from experience
 
 ### v5.7 - Utilize gh observer extension (2026-02-16)
+
+- **Related PR:** [#97](https://github.com/fini-net/template-repo/pull/97)
 
 Utilize the [gh observer extension](https://github.com/fini-net/gh-observer) if it is installed.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ When using this template for a new project:
 - Hidden recipes (prefixed with `_`) are internal helpers and not shown in `just --list`
 - The `again` recipe is for iterating on PRs: push, update description, watch checks
 - Release notes for workflow changes are tracked in `.just/RELEASE_NOTES.md`.  Each new version should get an entry in this file.
-- Changes to the `.just/*` files should increment the version number for the the `pr` recipe in `.just/gh-procerss.just`
+- Changes to the `.just/*` files should increment the version number for the `pr` recipe in `.just/gh-process.just`
 
 ## Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,8 @@ When using this template for a new project:
 - just colors come from built-in constants: `{{GREEN}}`, `{{BLUE}}`, `{{RED}}`, `{{YELLOW}}`, `{{NORMAL}}`
 - Hidden recipes (prefixed with `_`) are internal helpers and not shown in `just --list`
 - The `again` recipe is for iterating on PRs: push, update description, watch checks
-- Release notes for workflow changes are tracked in `.just/RELEASE_NOTES.md`
+- Release notes for workflow changes are tracked in `.just/RELEASE_NOTES.md`.  Each new version should get an entry in this file.
+- Changes to the `.just/*` files should increment the version number for the the `pr` recipe in `.just/gh-procerss.just`
 
 ## Dependencies
 


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 💊 [just] release notes cleanup and v5.9 documented
- document v5.9, add links for v5.7 where regression was introduced
- remind Claude and other agents that we want to increment a version number and add release notes
- fix typos in new claude instructions
- update checksums

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)

