### PR TITLE
🛋️ [just] v6.0 adds claude recipe so it always runs from the repo root

### DIFF
--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,15 +1,23 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-04-23T17:24:08Z",
+  "generated_at": "2026-04-23T17:36:08Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
+        {
+          "checksum": "7ca68ca4563ecef394f26b2119a6651db398e22ce431bf870d23ab4d28a62eb2",
+          "commit": "8a988731ec333260426ec71946e08471bb1a2321",
+          "date": "2026-04-23T10:25:42-07:00",
+          "version": "v6.0",
+          "is_latest": true
+        }
+,
         {
           "checksum": "c792bfe1dd3c22034617a767311ce3c150940e76c17c68977f8bf821d289be64",
           "commit": "7cbea684926ae42eb667dc2e9e5d059cfc3074b1",
           "date": "2026-01-24T20:16:01-08:00",
           "version": "",
-          "is_latest": true
+          "is_latest": false
         }
 ]},
     ".just/clean-template.just": {"versions": [
@@ -146,11 +154,19 @@
 ]},
     ".just/gh-process.just": {"versions": [
         {
+          "checksum": "a3212fdf74cb0c5719e819944c45a75929221056d40f20151fe7c3c8a1bbbc4d",
+          "commit": "9e300c69530dbbe84d38379107657216eb7c84ea",
+          "date": "2026-04-23T10:32:43-07:00",
+          "version": "v6.0",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "478383a2ef0c73ce1d5b6b8686bfdd1640458b6777f19f666ec51b490d546bbe",
           "commit": "b853d0eeecf7ce83e501c9e2ba129547577bf186",
           "date": "2026-04-19T10:29:45-07:00",
           "version": "",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-04-23T17:12:23Z",
+  "generated_at": "2026-04-23T17:24:08Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,15 +1,23 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-04-23T17:36:08Z",
+  "generated_at": "2026-04-23T17:44:01Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
+        {
+          "checksum": "9a1fa8eef2db72259e56c809d128bd65d7630bfd16d8c1be9039715decc6b435",
+          "commit": "6b9548524846332cc3c87b4333a657bc29f657c0",
+          "date": "2026-04-23T10:43:48-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
         {
           "checksum": "7ca68ca4563ecef394f26b2119a6651db398e22ce431bf870d23ab4d28a62eb2",
           "commit": "8a988731ec333260426ec71946e08471bb1a2321",
           "date": "2026-04-23T10:25:42-07:00",
           "version": "v6.0",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -6,9 +6,11 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ### v6.0 - Claude Code Launch Recipe (2026-04-23)
 
+- **Related PR:** [#125](https://github.com/fini-net/template-repo/pull/125)
 - Fixes issue [#112](https://github.com/fini-net/template-repo/issues/112)
-- **Add `claude` recipe** - New recipe in `.just/claude.just` that launches Claude Code from the repo root
-- Just recipes run from the repo root by default, so no `cd` is needed — running `just claude` always starts Claude Code with full project context regardless of the user's current directory
+
+**Add `claude` recipe** - New recipe in `.just/claude.just` that launches Claude Code from the repo root.
+Just recipes run from the repo root by default, so no `cd` is needed — running `just claude` always starts Claude Code with full project context regardless of the user's current directory
 
 ### v5.9 - PR Checks Requires Active Pull Request (2026-04-19)
 

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -4,6 +4,12 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ## April 2026 - Guard rails
 
+### v6.0 - Claude Code Launch Recipe (2026-04-23)
+
+- Fixes issue [#112](https://github.com/fini-net/template-repo/issues/112)
+- **Add `claude` recipe** - New recipe in `.just/claude.just` that launches Claude Code from the repo root
+- Just recipes run from the repo root by default, so no `cd` is needed — running `just claude` always starts Claude Code with full project context regardless of the user's current directory
+
 ### v5.9 - PR Checks Requires Active Pull Request (2026-04-19)
 
 - Fixes issue [#115](https://github.com/fini-net/template-repo/issues/115)

--- a/.just/claude.just
+++ b/.just/claude.just
@@ -2,10 +2,10 @@
 
 claude_settings_file := ".claude/settings.local.json"
 
-# Launch Claude Code in the repo root
+# Launch Claude Code in the repo root (with arguments optionally)
 [group('Claude Code')]
-claude:
-    claude
+claude *args:
+    claude {{ args }}
 
 # Sort Claude Code permissions in canonical order
 [group('Claude Code')]

--- a/.just/claude.just
+++ b/.just/claude.just
@@ -2,6 +2,11 @@
 
 claude_settings_file := ".claude/settings.local.json"
 
+# Launch Claude Code in the repo root
+[group('Claude Code')]
+claude:
+    claude
+
 # Sort Claude Code permissions in canonical order
 [group('Claude Code')]
 claude_permissions_sort:

--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -13,7 +13,7 @@ sync:
     git pull
     git status --porcelain # stp
 
-# PR create v5.9
+# PR create v6.0
 [group('Process')]
 pr: _has_commits && pr_checks
     #!/usr/bin/env bash


### PR DESCRIPTION
Fixes #112 

<!-- PR_BODY_DONE_START -->
## Done

- 🛋️ [just] v6.0 adds claude recipe so it always runs from the repo root
- actual version bump to v6.0
- update release notes with the PR
- regenerate checksums
- pass through arguments
- regenerate checksums

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)


