### PR TITLE
📐 [just] better error handling and path matching in template-sync.just, fixes #116

### DIFF
--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-04-23T21:59:51Z",
+  "generated_at": "2026-04-23T22:04:25Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -518,11 +518,19 @@
 ]},
     ".just/template-sync.just": {"versions": [
         {
+          "checksum": "b61843432a55e6868f3f532694f96e75c360a22eda6d31f8ba7ced3d5d1dc7a8",
+          "commit": "0ce316208051e061491747d60031d82167ecc303",
+          "date": "2026-04-23T15:04:23-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "d24645575abe143d8654a986033a5bf32fc9134864fcbc36dc1d6ea9c17fca82",
           "commit": "6522134f0c1dfb69b32b5063147f4e275f3da0e9",
           "date": "2026-04-23T14:59:00-07:00",
           "version": "",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {
@@ -724,11 +732,19 @@
 ]},
     ".just/lib/template_update.sh": {"versions": [
         {
+          "checksum": "dfddad2e4d078b2cb3dc79f84fe867caabc3445bcf7f5e144e80af06214c6c0e",
+          "commit": "0ce316208051e061491747d60031d82167ecc303",
+          "date": "2026-04-23T15:04:23-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "51874ed04c29ebe54b890152c75f93337134a33f8821a242612b150c49d5fdaf",
           "commit": "6522134f0c1dfb69b32b5063147f4e275f3da0e9",
           "date": "2026-04-23T14:59:00-07:00",
           "version": "",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-04-23T20:31:59Z",
+  "generated_at": "2026-04-23T21:59:51Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -155,8 +155,8 @@
     ".just/gh-process.just": {"versions": [
         {
           "checksum": "505f550b2855afb6364dc11e4716fce0839e9265a78f3c01ccf8985937daf9b4",
-          "commit": "32083af47930c599449e6e55e2c4f466e0554360",
-          "date": "2026-04-23T12:14:57-07:00",
+          "commit": "eb298fa0258c406fbfdd3b1ab3b4d18f6e8efdad",
+          "date": "2026-04-23T13:36:50-07:00",
           "version": "v6.1",
           "is_latest": true
         }
@@ -461,26 +461,10 @@
     ".just/repo-toml.just": {"versions": [
         {
           "checksum": "58fa8830111fd65a8c8e25409b57395c1df76109365115d3895c2db7e1100bfa",
-          "commit": "e27281b90bd46a9b04dc85ae716fae1c2706b057",
-          "date": "2026-04-23T13:31:50-07:00",
-          "version": "",
-          "is_latest": true
-        }
-,
-        {
-          "checksum": "6ac07fcdae9719888212daac9b1573628aadbeafa18e1bd4c398019cd77a1ef0",
-          "commit": "6db623655a5a1835ae14f84e098364aa59c31e86",
-          "date": "2026-04-23T12:33:04-07:00",
-          "version": "",
-          "is_latest": false
-        }
-,
-        {
-          "checksum": "d45250491ed2ae7ffb4a0a406f455b350bfc7eaf51231c9be2367ba6fda35a6c",
-          "commit": "32083af47930c599449e6e55e2c4f466e0554360",
-          "date": "2026-04-23T12:14:57-07:00",
+          "commit": "eb298fa0258c406fbfdd3b1ab3b4d18f6e8efdad",
+          "date": "2026-04-23T13:36:50-07:00",
           "version": "v6.1",
-          "is_latest": false
+          "is_latest": true
         }
 ,
         {
@@ -534,11 +518,27 @@
 ]},
     ".just/template-sync.just": {"versions": [
         {
+          "checksum": "d24645575abe143d8654a986033a5bf32fc9134864fcbc36dc1d6ea9c17fca82",
+          "commit": "6522134f0c1dfb69b32b5063147f4e275f3da0e9",
+          "date": "2026-04-23T14:59:00-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
+          "checksum": "a2d5de6afbb398a8a6dfb9dfa4544ed8bc88ccc497a8d74143f3280295d398c0",
+          "commit": "e9d0168b73c3557c4f11143a905599b08854cb1b",
+          "date": "2026-04-23T14:53:28-07:00",
+          "version": "",
+          "is_latest": false
+        }
+,
+        {
           "checksum": "d3757c40d03a655b13a629301a39add3d63b93aa9b5850731255ad85ad4174be",
           "commit": "73d9e57268ef1bdf2662ea7c5437f455128c1d1d",
           "date": "2026-03-22T20:52:08-07:00",
           "version": "",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {
@@ -724,11 +724,27 @@
 ]},
     ".just/lib/template_update.sh": {"versions": [
         {
+          "checksum": "51874ed04c29ebe54b890152c75f93337134a33f8821a242612b150c49d5fdaf",
+          "commit": "6522134f0c1dfb69b32b5063147f4e275f3da0e9",
+          "date": "2026-04-23T14:59:00-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
+          "checksum": "068e64c2b04c3a6bb947acb42b28f8ac85370e5688c722360cec86e85b29848c",
+          "commit": "e9d0168b73c3557c4f11143a905599b08854cb1b",
+          "date": "2026-04-23T14:53:28-07:00",
+          "version": "",
+          "is_latest": false
+        }
+,
+        {
           "checksum": "4161bedd6b05a6070020f562ccc451c637895ab79efdca50659828333e647b0e",
           "commit": "090d286b1df83bf38d1590826812741d184f1d41",
           "date": "2026-03-22T21:15:59-07:00",
           "version": "",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-04-23T22:04:25Z",
+  "generated_at": "2026-04-23T23:17:04Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -154,11 +154,19 @@
 ]},
     ".just/gh-process.just": {"versions": [
         {
+          "checksum": "d870a87180c6569fd832f3788efd6686c703c4c847da509dc993cb000662c0ac",
+          "commit": "b3abe5f7bea1fdbfc148e7126ffd661498dc2c2b",
+          "date": "2026-04-23T16:16:15-07:00",
+          "version": "v6.2",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "505f550b2855afb6364dc11e4716fce0839e9265a78f3c01ccf8985937daf9b4",
           "commit": "eb298fa0258c406fbfdd3b1ab3b4d18f6e8efdad",
           "date": "2026-04-23T13:36:50-07:00",
           "version": "v6.1",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -4,6 +4,30 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ## April 2026 - Guard rails
 
+### v6.2 - Template Sync Refinements (2026-04-23)
+
+- **Related PR:** [#129](https://github.com/fini-net/template-repo/pull/129)
+- Fixes issue [#116](https://github.com/fini-net/template-repo/issues/116)
+
+Improved robustness of the template sync system with better error handling
+and smarter path matching for cleaned files.
+
+**Changes:**
+
+- **Checksum verification on download** - `template_update.sh` now verifies
+  downloaded files against expected checksums before moving them into place,
+  catching corrupted or incomplete downloads immediately. Passes the expected
+  checksum from the manifest to `download_file()` so mismatches are detected
+  before overwriting local files.
+- **Directory-aware cleaned file matching** - Both `template-sync.just` and
+  `template_update.sh` now use `startswith` matching instead of exact path
+  matching when checking cleaned files. This means if a directory is listed
+  in `cleaned_files`, any file under that directory is properly recognized as
+  cleaned, not just the exact directory path itself.
+- **Missing checksum tool error** - `checksums_verify` recipe now explicitly
+  exits with an error message if neither `sha256sum` nor `shasum` is found,
+  instead of silently producing empty output.
+
 ### v6.1 - Shell Escaping in repo_toml_generate (2026-04-23)
 
 - Fixes issue [#117](https://github.com/fini-net/template-repo/issues/117)

--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -13,7 +13,7 @@ sync:
     git pull
     git status --porcelain # stp
 
-# PR create v6.1
+# PR create v6.2
 [group('Process')]
 pr: _has_commits && pr_checks
     #!/usr/bin/env bash

--- a/.just/lib/template_update.sh
+++ b/.just/lib/template_update.sh
@@ -136,7 +136,7 @@ process_file() {
 
 	# Check if this is a cleaned file (or under a cleaned directory)
 	local is_cleaned=false
-	if jq -e --arg fp "$filepath" '.cleaned_files // [] | any($fp | startwith(.))' "$MANIFEST_FILE" >/dev/null 2>&1; then
+	if jq -e --arg fp "$filepath" '.cleaned_files // [] | any($fp | startswith(.))' "$MANIFEST_FILE" >/dev/null 2>&1; then
 		is_cleaned=true
 	fi
 

--- a/.just/lib/template_update.sh
+++ b/.just/lib/template_update.sh
@@ -136,7 +136,7 @@ process_file() {
 
 	# Check if this is a cleaned file (or under a cleaned directory)
 	local is_cleaned=false
-	if jq -e --arg fp "$filepath" '.cleaned_files // [] | any(startswith($fp))' "$MANIFEST_FILE" >/dev/null 2>&1; then
+	if jq -e --arg fp "$filepath" '.cleaned_files // [] | any($fp | startwith(.))' "$MANIFEST_FILE" >/dev/null 2>&1; then
 		is_cleaned=true
 	fi
 

--- a/.just/lib/template_update.sh
+++ b/.just/lib/template_update.sh
@@ -73,6 +73,7 @@ fetch_manifest() {
 # Download a file with verification
 download_file() {
 	local filepath="$1"
+	local expected_checksum="${2:-}"
 	local temp_file="${filepath}.tmp"
 	local backup_file="${filepath}.pre-update-backup"
 	local -r max=$MAX_RETRIES
@@ -91,6 +92,18 @@ download_file() {
 				rm -f "$temp_file"
 				[[ -f "$backup_file" ]] && mv "$backup_file" "$filepath"
 				return 1
+			fi
+
+			# Verify checksum if expected checksum provided
+			if [[ -n "$expected_checksum" ]]; then
+				local downloaded_checksum
+				downloaded_checksum=$(compute_checksum "$temp_file")
+				if [[ "$downloaded_checksum" != "$expected_checksum" ]]; then
+					echo -e "      ${RED}Checksum mismatch${NORMAL}"
+					rm -f "$temp_file"
+					[[ -f "$backup_file" ]] && mv "$backup_file" "$filepath"
+					return 1
+				fi
 			fi
 
 			# Move into place and clean up
@@ -121,9 +134,9 @@ download_file() {
 process_file() {
 	local filepath="$1"
 
-	# Check if this is a cleaned file (should be skipped if missing)
+	# Check if this is a cleaned file (or under a cleaned directory)
 	local is_cleaned=false
-	if jq -e --arg fp "$filepath" '.cleaned_files // [] | index($fp) != null' "$MANIFEST_FILE" >/dev/null 2>&1; then
+	if jq -e --arg fp "$filepath" '.cleaned_files // [] | any(startswith($fp))' "$MANIFEST_FILE" >/dev/null 2>&1; then
 		is_cleaned=true
 	fi
 
@@ -150,7 +163,7 @@ process_file() {
 			return
 		fi
 		echo -e "  ${BLUE}↓${NORMAL} $filepath - new file, downloading"
-		if download_file "$filepath"; then
+		if download_file "$filepath" "$latest_checksum"; then
 			echo -e "      ${GREEN}Downloaded successfully${NORMAL}"
 			((downloaded_new_count++)) || true
 		else
@@ -195,7 +208,7 @@ process_file() {
 	fi
 
 	echo -e "  ${BLUE}⬆${NORMAL} $filepath - updating${version_info}"
-	if download_file "$filepath"; then
+	if download_file "$filepath" "$latest_checksum"; then
 		echo -e "      ${GREEN}Updated successfully${NORMAL}"
 		((updated_count++)) || true
 	else

--- a/.just/template-sync.just
+++ b/.just/template-sync.just
@@ -92,7 +92,7 @@ checksums_verify:
     while IFS= read -r filepath; do
         if [[ ! -f "$filepath" ]]; then
             # Check if this is a cleaned file (or under a cleaned directory)
-            if jq -e --arg fp "$filepath" '.cleaned_files // [] | any($fp | startwith(.))' "$MANIFEST_FILE" >/dev/null 2>&1; then
+            if jq -e --arg fp "$filepath" '.cleaned_files // [] | any($fp | startswith(.))' "$MANIFEST_FILE" >/dev/null 2>&1; then
                 echo "  {{BLUE}}⊘{{NORMAL}} $filepath - removed by clean_template"
             else
                 echo "  {{YELLOW}}⊘{{NORMAL}} $filepath - not present locally"

--- a/.just/template-sync.just
+++ b/.just/template-sync.just
@@ -66,6 +66,9 @@ checksums_verify:
             sha256sum "$file" | awk '{print $1}'
         elif command -v shasum &>/dev/null; then
             shasum -a 256 "$file" | awk '{print $1}'
+        else
+            echo "Error: Neither sha256sum nor shasum found" >&2
+            exit 1
         fi
     }
 
@@ -88,8 +91,8 @@ checksums_verify:
 
     while IFS= read -r filepath; do
         if [[ ! -f "$filepath" ]]; then
-            # Check if this is a cleaned file
-            if jq -e --arg fp "$filepath" '.cleaned_files // [] | index($fp) != null' "$MANIFEST_FILE" >/dev/null 2>&1; then
+            # Check if this is a cleaned file (or under a cleaned directory)
+            if jq -e --arg fp "$filepath" '.cleaned_files // [] | any(startswith($fp))' "$MANIFEST_FILE" >/dev/null 2>&1; then
                 echo "  {{BLUE}}⊘{{NORMAL}} $filepath - removed by clean_template"
             else
                 echo "  {{YELLOW}}⊘{{NORMAL}} $filepath - not present locally"

--- a/.just/template-sync.just
+++ b/.just/template-sync.just
@@ -92,7 +92,7 @@ checksums_verify:
     while IFS= read -r filepath; do
         if [[ ! -f "$filepath" ]]; then
             # Check if this is a cleaned file (or under a cleaned directory)
-            if jq -e --arg fp "$filepath" '.cleaned_files // [] | any(startswith($fp))' "$MANIFEST_FILE" >/dev/null 2>&1; then
+            if jq -e --arg fp "$filepath" '.cleaned_files // [] | any($fp | startwith(.))' "$MANIFEST_FILE" >/dev/null 2>&1; then
                 echo "  {{BLUE}}⊘{{NORMAL}} $filepath - removed by clean_template"
             else
                 echo "  {{YELLOW}}⊘{{NORMAL}} $filepath - not present locally"


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 📐 [just] better error handling and path matching in template-sync.just, fixes #116
- kimi-k2.6:cloud fixes issues found by Claude
- regenerate checksums
- back to glm-5.1
- regenerate checksums
- v6.2 version bump and release notes
- regenerate checksums

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)



