### PR TITLE
🎱 [just] cue is a prereq and tighten url validation, fixes #118

### DIFF
--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-04-23T23:52:08Z",
+  "generated_at": "2026-04-24T00:42:39Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -89,18 +89,10 @@
     ".just/copilot.just": {"versions": [
         {
           "checksum": "91eb7eaaf47705a2cce883eb747f3d1a2b47d3d76b941646e2605464f8db853d",
-          "commit": "064f52039e9c07a4d379b1dca5003dd12083ed74",
-          "date": "2026-04-23T16:40:14-07:00",
-          "version": "",
-          "is_latest": true
-        }
-,
-        {
-          "checksum": "2c1db92ede4ce144ce59f2b04664e7891a5df01a2995d8e88364f0c284f7ae04",
-          "commit": "1d678dafab1e3ee9f00e198c86a384f4fb391cf7",
-          "date": "2026-04-23T16:35:58-07:00",
+          "commit": "30aee89c82f35514ba7ee0189b89530bf7a7423f",
+          "date": "2026-04-23T17:29:04-07:00",
           "version": "v6.3",
-          "is_latest": false
+          "is_latest": true
         }
 ,
         {
@@ -170,11 +162,19 @@
 ]},
     ".just/gh-process.just": {"versions": [
         {
-          "checksum": "a50a1544b0b87de77e643ac4e5065078b35d3060cb9c9cc541e0f149eebb9d26",
-          "commit": "1d678dafab1e3ee9f00e198c86a384f4fb391cf7",
-          "date": "2026-04-23T16:35:58-07:00",
-          "version": "v6.3",
+          "checksum": "e181b0a99ff2a310ee800377a0bdbb764e4fa65a60578d9a0ab8b3a412f4748e",
+          "commit": "35daed0c33302faa88c8384fff262c3b3e234d29",
+          "date": "2026-04-23T17:42:23-07:00",
+          "version": "v6.4",
           "is_latest": true
+        }
+,
+        {
+          "checksum": "a50a1544b0b87de77e643ac4e5065078b35d3060cb9c9cc541e0f149eebb9d26",
+          "commit": "30aee89c82f35514ba7ee0189b89530bf7a7423f",
+          "date": "2026-04-23T17:29:04-07:00",
+          "version": "v6.3",
+          "is_latest": false
         }
 ,
         {
@@ -721,11 +721,19 @@
 ]},
     ".just/lib/install-prerequisites.sh": {"versions": [
         {
+          "checksum": "7d9da1aa910f91b95c8dde5e12f64835b936aba8b6eae28df9e8946641f5f044",
+          "commit": "38256799c533a4e7f350890941fc70d8a4ab08ec",
+          "date": "2026-04-23T17:38:49-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "e9da4a5f97cfe9c9df74aff01421436b8bc89fd2f806f5a93a1582931502341d",
           "commit": "64dd156676bd6b2e6c11cd2d518e5beb61de6433",
           "date": "2026-01-28T17:47:51-08:00",
           "version": "",
-          "is_latest": true
+          "is_latest": false
         }
 ]},
     ".just/lib/pr_body_test.sh": {"versions": [

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-04-24T00:47:29Z",
+  "generated_at": "2026-04-24T00:56:27Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-04-24T00:42:39Z",
+  "generated_at": "2026-04-24T00:47:29Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -721,11 +721,19 @@
 ]},
     ".just/lib/install-prerequisites.sh": {"versions": [
         {
+          "checksum": "153a826274ff03b0c42ccfb5024b202c78f02153804c0ef6c98b1df103c5dca5",
+          "commit": "59dd8b462fbe2651b3f83c5bd5b4c6ee5ce4dc19",
+          "date": "2026-04-23T17:47:15-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "7d9da1aa910f91b95c8dde5e12f64835b936aba8b6eae28df9e8946641f5f044",
           "commit": "38256799c533a4e7f350890941fc70d8a4ab08ec",
           "date": "2026-04-23T17:38:49-07:00",
           "version": "",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -4,6 +4,22 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ## April 2026 - Guard rails
 
+### v6.4 - Prerequisites Update and Cue Schema Fix (2026-04-23)
+
+- **Related PR:** TBD
+
+Added `cue` as a required tool in the prerequisites installation script and
+fixed a regex bug in the repo-toml Cue schema.
+
+**Changes:**
+
+- **Cue in prerequisites** - Added `cue` (the Cue validation tool) to the
+  `install-prerequisites.sh` script: detection, Homebrew installation on
+  macOS, and manual install instructions for Linux and other platforms.
+- **Web URL regex fix** - Changed `web_url` regex in `docs/repo-toml.cue`
+  from `[^/]+/.+` to `[^/]+/[^/]+` to prevent matching URLs with trailing
+  path segments that aren't valid repository URLs.
+
 ### v6.3 - Copilot Path Encoding and Portability Fixes (2026-04-23)
 
 - **Related PR:** [#130](https://github.com/fini-net/template-repo/pull/130)

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -6,7 +6,8 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ### v6.4 - Prerequisites Update and Cue Schema Fix (2026-04-23)
 
-- **Related PR:** TBD
+- **Related PR:** [#131](https://github.com/fini-net/template-repo/pull/131)
+- Fixes issue [#118](https://github.com/fini-net/template-repo/issues/118)
 
 Added `cue` as a required tool in the prerequisites installation script and
 fixed a regex bug in the repo-toml Cue schema.
@@ -69,6 +70,7 @@ and smarter path matching for cleaned files.
 
 ### v6.1 - Shell Escaping in repo_toml_generate (2026-04-23)
 
+- **Related PR:** [#126](https://github.com/fini-net/template-repo/pull/126)
 - Fixes issue [#117](https://github.com/fini-net/template-repo/issues/117)
 
 Fixed improper shell quoting in `repo_toml_generate` that could produce broken
@@ -135,6 +137,8 @@ This was a regression that slipped in during v5.7. The history of the
 ## March 2026 - More resilience
 
 ### v5.8.1 - Executable permissions for template updates (2026-03-22)
+
+- **Related PR:** [#110](https://github.com/fini-net/template-repo/pull/110)
 
 Fixed an issue where downloaded shell scripts from template-repo would not have
 executable permissions set. Previously, files like `.just/lib/template_update.sh`
@@ -338,6 +342,8 @@ Implementation details:
 - Complements existing copilot_pick (#67, #72) workflow
 
 ### v5.0 - Robust PR Body Updates with HTML Markers
+
+- **Related PR:** [#78](https://github.com/fini-net/template-repo/pull/78)
 
 Completely rewrote the `pr_update` recipe to eliminate data loss when updating
 PR descriptions. The previous AWK-based implementation (v4.0-4.4) was fragile
@@ -591,6 +597,8 @@ commits, it maintains proper markdown formatting with blank lines separating
 different sections of the PR description.
 
 ### v4.3 - Release Tag Visibility
+
+- **Related PR:** [#49](https://github.com/fini-net/template-repo/pull/49)
 
 Enhanced the `release` recipe to automatically pull the newly created tag so it's
 immediately visible in your local repository. Previously, after running

--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -13,7 +13,7 @@ sync:
     git pull
     git status --porcelain # stp
 
-# PR create v6.3
+# PR create v6.4
 [group('Process')]
 pr: _has_commits && pr_checks
     #!/usr/bin/env bash

--- a/.just/lib/install-prerequisites.sh
+++ b/.just/lib/install-prerequisites.sh
@@ -3,7 +3,7 @@
 #
 # Usage: ./.just/lib/install-prerequisites.sh
 #
-# This script checks for required tools (just, gh, shellcheck, markdownlint-cli2, jq, gum)
+# This script checks for required tools (just, gh, shellcheck, markdownlint-cli2, jq, gum, cue)
 # and helps install them:
 #
 # - macOS: Automatically installs missing tools using Homebrew
@@ -64,6 +64,12 @@ if command -v gum &>/dev/null; then
 	INSTALLED+=("gum")
 else
 	MISSING+=("gum")
+fi
+
+if command -v cue &>/dev/null; then
+	INSTALLED+=("cue")
+else
+	MISSING+=("cue")
 fi
 
 # report what's already installed
@@ -163,6 +169,15 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 				echo -e "${RED}Failed to install gum${NC}"
 			fi
 			;;
+		cue)
+			echo -e "${CYAN}Installing cue...${NC}"
+			if brew install cue; then
+				INSTALL_SUCCESS+=("cue")
+			else
+				INSTALL_FAILED+=("cue")
+				echo -e "${RED}Failed to install cue${NC}"
+			fi
+			;;
 		esac
 	done
 
@@ -249,6 +264,15 @@ elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		gum)
 			echo -e "${CYAN}Install gum:${NC} See https://github.com/charmbracelet/gum#installation"
 			;;
+		cue)
+			if [[ "$PKG_MGR" == "apt-get" ]]; then
+				echo -e "${CYAN}Install cue:${NC} See https://github.com/cue-lang/cue#installation"
+			elif [[ "$PKG_MGR" == "dnf" ]]; then
+				echo -e "${CYAN}Install cue:${NC} See https://github.com/cue-lang/cue#installation"
+			elif [[ "$PKG_MGR" == "pacman" ]]; then
+				echo -e "${CYAN}Install cue:${NC} See https://github.com/cue-lang/cue#installation"
+			fi
+			;;
 		esac
 	done
 
@@ -270,6 +294,7 @@ else
 	echo "  markdownlint-cli2: npm install -g markdownlint-cli2"
 	echo "  jq: https://stedolan.github.io/jq/download/"
 	echo "  gum: https://github.com/charmbracelet/gum#installation"
+	echo "  cue: https://github.com/cue-lang/cue#installation"
 	exit 1
 fi
 

--- a/.just/lib/install-prerequisites.sh
+++ b/.just/lib/install-prerequisites.sh
@@ -265,13 +265,7 @@ elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
 			echo -e "${CYAN}Install gum:${NC} See https://github.com/charmbracelet/gum#installation"
 			;;
 		cue)
-			if [[ "$PKG_MGR" == "apt-get" ]]; then
-				echo -e "${CYAN}Install cue:${NC} See https://github.com/cue-lang/cue#installation"
-			elif [[ "$PKG_MGR" == "dnf" ]]; then
-				echo -e "${CYAN}Install cue:${NC} See https://github.com/cue-lang/cue#installation"
-			elif [[ "$PKG_MGR" == "pacman" ]]; then
-				echo -e "${CYAN}Install cue:${NC} See https://github.com/cue-lang/cue#installation"
-			fi
+			echo -e "${CYAN}Install cue:${NC} See https://github.com/cue-lang/cue#installation"
 			;;
 		esac
 	done

--- a/docs/repo-toml.cue
+++ b/docs/repo-toml.cue
@@ -21,7 +21,7 @@ urls?: {
 	git_ssh?: string & =~"^git@github\\.com:[^/]+/.+\\.git$"
 
 	// Web URL for repository viewing
-	web_url?: string & =~"^https://github\\.com/[^/]+/.+$"
+	web_url?: string & =~"^https://github\\.com/[^/]+/[^/]+$"
 }
 
 // Flags section contains boolean feature flags


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🎱 [just] cue is a prereq and tighten url validation, fixes #118
- version bump to v6.4
- start release notes
- regenerate checksums
- simplify Linux docs for cue dependancy
- regenerate checksums
- add 5 (FIVE!) missing PRs to release notes
- regenerate checksums

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)


