### PR TITLE
✂️  [just] gh-process v6.8 fixes trailing blank lines in PR descriptions, fixes #173

### DIFF
--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-24T02:18:00Z",
+  "generated_at": "2026-06-24T02:57:03Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -170,11 +170,19 @@
 ]},
     ".just/gh-process.just": {"versions": [
         {
+          "checksum": "a27b4491f1732048f3d3fc104837d87cf2cfe87beae4103a37cd96d7c2f47e16",
+          "commit": "a0f3ff8f69dae2d44488b2d6f9fcaf839ba9669a",
+          "date": "2026-06-23T19:50:08-07:00",
+          "version": "v6.8",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "93f084b0258c2eb83d5f8108e2c77b369349f1f40e0af4fe0bb4460966fbfd42",
           "commit": "59271f4fede60350d8a141729fd92fe798ab710a",
           "date": "2026-06-20T14:53:57-04:00",
           "version": "v6.7",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {
@@ -790,11 +798,19 @@
 ]},
     ".just/lib/update_pr_body.sh": {"versions": [
         {
+          "checksum": "3f7ed129dc17ec2022a430b0786d2cfd52bbd707a3badfaad4eff824bbd11bf0",
+          "commit": "a0f3ff8f69dae2d44488b2d6f9fcaf839ba9669a",
+          "date": "2026-06-23T19:50:08-07:00",
+          "version": "v6.8",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "32c1e89ec2c81d7e8326564a184dd37e294545c77aa9f0ea13ca2b26759a6653",
           "commit": "c25f8d5f0d1dfef88f9ab988c2aec9bb6712c8d3",
           "date": "2026-03-21T12:36:04-07:00",
           "version": "v5.8",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-20T18:49:01Z",
+  "generated_at": "2026-06-24T02:18:00Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -171,8 +171,8 @@
     ".just/gh-process.just": {"versions": [
         {
           "checksum": "93f084b0258c2eb83d5f8108e2c77b369349f1f40e0af4fe0bb4460966fbfd42",
-          "commit": "5cb5b6ae03757ed7a0fa8a5c9b5c609ffeb8b545",
-          "date": "2026-06-20T11:37:01-07:00",
+          "commit": "59271f4fede60350d8a141729fd92fe798ab710a",
+          "date": "2026-06-20T14:53:57-04:00",
           "version": "v6.7",
           "is_latest": true
         }
@@ -674,8 +674,8 @@
     ".just/lib/generate_checksums.sh": {"versions": [
         {
           "checksum": "03cb85d7973e998759e17f858dd6756aa69feacd35ab01dbbed0e75ba21f2bd5",
-          "commit": "5cb5b6ae03757ed7a0fa8a5c9b5c609ffeb8b545",
-          "date": "2026-06-20T11:37:01-07:00",
+          "commit": "59271f4fede60350d8a141729fd92fe798ab710a",
+          "date": "2026-06-20T14:53:57-04:00",
           "version": "v6.7",
           "is_latest": true
         }
@@ -742,18 +742,10 @@
     ".just/lib/template_update.sh": {"versions": [
         {
           "checksum": "f5008d007e44dc23ac4b66da8c71edcaa4c0b6bccd6d5c029cb65e0ac7f3a0da",
-          "commit": "33e51a9f17de34864445fecef1dccc1bc75b24f8",
-          "date": "2026-06-20T11:48:45-07:00",
-          "version": "",
-          "is_latest": true
-        }
-,
-        {
-          "checksum": "0b5b9e1f35ca0837962981f9b2c570962529f887c18ddc5ae2b67e2696b2d40d",
-          "commit": "5cb5b6ae03757ed7a0fa8a5c9b5c609ffeb8b545",
-          "date": "2026-06-20T11:37:01-07:00",
+          "commit": "59271f4fede60350d8a141729fd92fe798ab710a",
+          "date": "2026-06-20T14:53:57-04:00",
           "version": "v6.7",
-          "is_latest": false
+          "is_latest": true
         }
 ,
         {

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -2,6 +2,51 @@
 
 This file tracks the evolution of the Git/GitHub workflow automation module.
 
+## June 2026 - PR body trailing blank line fix
+
+### v6.8 - Trailing blank line accumulation fix (2026-06-23)
+
+- Fixes issue [#173](https://github.com/fini-net/template-repo/issues/173)
+
+Running `just again` repeatedly on a PR caused trailing blank lines to
+accumulate at the bottom of the PR description. Each `pr_update` cycle
+added ~2 trailing blank lines, so a PR iterated on 8 times ended up with
+~16 trailing blank lines after the `## Meta` section.
+
+**Root cause:** A feedback loop between three actors, each appending a
+trailing newline:
+
+1. GitHub's REST/GraphQL API appends a trailing `\n` when storing a PR
+   body via `gh pr edit --body-file`.
+2. `jq -r '.body'` in `pr_update` appends its own trailing `\n` (jq
+   always emits a trailing newline on raw output).
+3. `.just/lib/update_pr_body.sh` emitted `footer_content` verbatim,
+   preserving trailing blank lines instead of trimming them.
+
+**Changes:**
+
+- **Trim trailing blank lines from `footer_content`** -
+  `.just/lib/update_pr_body.sh` now strips trailing empty entries from
+  the `footer_content` bash array before emitting the footer. This
+  breaks the accumulation cycle at the parser regardless of how many
+  newlines the GitHub API or jq add during round-trips. The header is
+  intentionally left untrimmed to keep the fix scoped to the documented
+  bug.
+- **Regression test fixture** - Added
+  `.just/test/fixtures/pr_bodies/15_trailing_blanks/` with an input
+  body carrying 4 trailing blank lines (simulating the post-round-trip
+  state after a few `pr_update` cycles) and an expected output with
+  those blanks stripped. Auto-discovered by `pr_body_test.sh`.
+- **Version bump** - `.just/gh-process.just` `pr` recipe comment bumped
+  from `v6.7` to `v6.8`.
+- **Checksums regenerated** - `.just/CHECKSUMS.json` updated so derived
+  repos can sync the fix via `just update_from_template`.
+
+**Related:** The v4.4 blank-line preservation fix (PR #50) correctly
+guarded blank lines *between* sections but inadvertently also preserved
+the trailing-blank-line accumulation path this issue describes. The v5.8
+CRLF normalization (PR #107) is a related robustness effort.
+
 ## June 2026 - Template sync robustness
 
 ### v6.7 - Fix update_from_template failures on test fixtures (2026-06-20)

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ### v6.8 - Trailing blank line accumulation fix (2026-06-23)
 
+- **Related PR:** [#174](https://github.com/fini-net/template-repo/pull/174)
 - Fixes issue [#173](https://github.com/fini-net/template-repo/issues/173)
 
 Running `just again` repeatedly on a PR caused trailing blank lines to
@@ -51,6 +52,7 @@ CRLF normalization (PR #107) is a related robustness effort.
 
 ### v6.7 - Fix update_from_template failures on test fixtures (2026-06-20)
 
+- **Related PR:** [#163](https://github.com/fini-net/template-repo/pull/163)
 - Fixes issue [#162](https://github.com/fini-net/template-repo/issues/162)
 
 Running `just update_from_template` in a derived repo failed with seven

--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -13,7 +13,7 @@ sync:
     git pull
     git status --porcelain # stp
 
-# PR create v6.7
+# PR create v6.8
 [group('Process')]
 pr: _has_commits && pr_checks
     #!/usr/bin/env bash

--- a/.just/lib/update_pr_body.sh
+++ b/.just/lib/update_pr_body.sh
@@ -116,6 +116,11 @@ if [[ "$state" == "$BEFORE_DONE" && ${#header_content[@]} -gt 0 ]]; then
     fi
 fi
 
+# Trim trailing blank lines from footer (GitHub API + jq round-trip accumulation; issue #173)
+while [[ ${#footer_content[@]} -gt 0 && -z "${footer_content[${#footer_content[@]}-1]}" ]]; do
+    unset 'footer_content[${#footer_content[@]}-1]'
+done
+
 # Output the updated PR body
 # 1. Header content (everything before Done)
 if [[ ${#header_content[@]} -gt 0 ]]; then

--- a/.just/test/fixtures/pr_bodies/15_trailing_blanks/commits.txt
+++ b/.just/test/fixtures/pr_bodies/15_trailing_blanks/commits.txt
@@ -1,0 +1,3 @@
+- abc1234 Initial commit
+- def5678 Fix bug
+- ghi9012 Add feature

--- a/.just/test/fixtures/pr_bodies/15_trailing_blanks/expected.md
+++ b/.just/test/fixtures/pr_bodies/15_trailing_blanks/expected.md
@@ -1,0 +1,12 @@
+<!-- PR_BODY_DONE_START -->
+## Done
+
+- abc1234 Initial commit
+- def5678 Fix bug
+- ghi9012 Add feature
+
+<!-- PR_BODY_DONE_END -->
+
+## Meta
+
+(Automated in `.just/gh-process.just`.)

--- a/.just/test/fixtures/pr_bodies/15_trailing_blanks/input.md
+++ b/.just/test/fixtures/pr_bodies/15_trailing_blanks/input.md
@@ -1,0 +1,15 @@
+<!-- PR_BODY_DONE_START -->
+## Done
+
+- abc1234 Initial commit
+- def5678 Fix bug
+
+<!-- PR_BODY_DONE_END -->
+
+## Meta
+
+(Automated in `.just/gh-process.just`.)
+
+
+
+

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,4 @@
+ignores:
+  - .just/test/fixtures/**
+  - .opencode/**
+config: .markdownlint.yml


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- ✂️  [just] gh-process v6.8 fixes trailing blank lines in PR descriptions, fixes #173
- ci(markdownlint): exclude test fixtures via .markdownlint-cli2.yaml
- just checksums_generate
- add PR links to release notes

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
