### PR TITLE
7️⃣ [just] gh-process v7.0 cleans up the version confusion in v6.9/v6.10

### DIFF
--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-24T04:46:24Z",
+  "generated_at": "2026-06-24T16:51:10Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -122,26 +122,10 @@
     ".just/cue-verify.just": {"versions": [
         {
           "checksum": "553f938f4f904a16d7b9f8a87e872001f0306bb9c2344d2c30c43d8297fb3af1",
-          "commit": "1f0b3c360013ba48d8c4fd82cbcdb589154f2900",
-          "date": "2026-06-23T21:31:30-07:00",
-          "version": "",
+          "commit": "d499305e2691f2601113a45003cf2dbf695f019d",
+          "date": "2026-06-23T21:50:26-07:00",
+          "version": "v6.9",
           "is_latest": true
-        }
-,
-        {
-          "checksum": "1b4223ba284ba2e57a6cd886f295bf68c32d08385ff2997e6501892903c2a346",
-          "commit": "626d593e054effd54a80fa77feb668fb467775a1",
-          "date": "2026-06-23T20:57:04-07:00",
-          "version": "",
-          "is_latest": false
-        }
-,
-        {
-          "checksum": "56c46fff3a567bab6fb6ace7f4e6cf916411b57589fff13eef290b3822275efc",
-          "commit": "d932422610014ce4a4d0fe7b0e4505d541272a91",
-          "date": "2026-06-23T20:26:00-07:00",
-          "version": "",
-          "is_latest": false
         }
 ,
         {
@@ -194,18 +178,18 @@
 ]},
     ".just/gh-process.just": {"versions": [
         {
-          "checksum": "e5a2c7264b94da22189f3abab5bf5d8d9a3d26e6710a8956ef57a61d292c9be8",
-          "commit": "dc027076a6eebcd286c189ec3eed185e6ce98a9f",
-          "date": "2026-06-23T21:41:29-07:00",
-          "version": "",
+          "checksum": "48851ec2d3d70fd1452f5bc67578a945366d60ffd29e07874a0ada94abbd4ee6",
+          "commit": "80f3451e2530ad38d5faa6024c4a6200315323bc",
+          "date": "2026-06-24T09:51:03-07:00",
+          "version": "v7.0",
           "is_latest": true
         }
 ,
         {
-          "checksum": "48851ec2d3d70fd1452f5bc67578a945366d60ffd29e07874a0ada94abbd4ee6",
-          "commit": "d932422610014ce4a4d0fe7b0e4505d541272a91",
-          "date": "2026-06-23T20:26:00-07:00",
-          "version": "",
+          "checksum": "e5a2c7264b94da22189f3abab5bf5d8d9a3d26e6710a8956ef57a61d292c9be8",
+          "commit": "d499305e2691f2601113a45003cf2dbf695f019d",
+          "date": "2026-06-23T21:50:26-07:00",
+          "version": "v6.9",
           "is_latest": false
         }
 ,
@@ -680,9 +664,9 @@
     ".just/testing.just": {"versions": [
         {
           "checksum": "edce3d39140b737e024c72c1fc69d3002994eb1eec42a6ec22ea40a8468744ed",
-          "commit": "1f0b3c360013ba48d8c4fd82cbcdb589154f2900",
-          "date": "2026-06-23T21:31:30-07:00",
-          "version": "",
+          "commit": "d499305e2691f2601113a45003cf2dbf695f019d",
+          "date": "2026-06-23T21:50:26-07:00",
+          "version": "v6.9",
           "is_latest": true
         }
 ,
@@ -730,18 +714,10 @@
     ".just/lib/cue_sync_test.sh": {"versions": [
         {
           "checksum": "08cb54a7535043a2f475fae69629312918bd5cd46a1af4cb95b5355dd1525a31",
-          "commit": "dc027076a6eebcd286c189ec3eed185e6ce98a9f",
-          "date": "2026-06-23T21:41:29-07:00",
-          "version": "",
+          "commit": "d499305e2691f2601113a45003cf2dbf695f019d",
+          "date": "2026-06-23T21:50:26-07:00",
+          "version": "v6.9",
           "is_latest": true
-        }
-,
-        {
-          "checksum": "d3f12e0a9be19ed1222bf59a3bc2f41c7f2e269a36faafc8ca497cd044acc175",
-          "commit": "1f0b3c360013ba48d8c4fd82cbcdb589154f2900",
-          "date": "2026-06-23T21:31:30-07:00",
-          "version": "",
-          "is_latest": false
         }
 ]},
     ".just/lib/generate_checksums.sh": {"versions": [

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-24T16:51:10Z",
+  "generated_at": "2026-06-24T17:01:11Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -178,11 +178,19 @@
 ]},
     ".just/gh-process.just": {"versions": [
         {
+          "checksum": "a6b69f79a5a9b9713c29ade4f27ebacc0b294c049a90b28ed84f226ad22dc0d5",
+          "commit": "0b9db5ffbc7c291a6503db30912c264d8b64bfcf",
+          "date": "2026-06-24T10:01:05-07:00",
+          "version": "v7.0",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "48851ec2d3d70fd1452f5bc67578a945366d60ffd29e07874a0ada94abbd4ee6",
           "commit": "80f3451e2530ad38d5faa6024c4a6200315323bc",
           "date": "2026-06-24T09:51:03-07:00",
           "version": "v7.0",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -2,6 +2,60 @@
 
 This file tracks the evolution of the Git/GitHub workflow automation module.
 
+## June 2026 - Version reconciliation
+
+### v7.0 - Resolve v6.9/v6.10 version-label confusion (2026-06-24)
+
+- **Related PR:** [#178](https://github.com/fini-net/template-repo/pull/178)
+
+PR #175 (v6.9) landed on `main` as a single squash commit, but the messy
+branch history that preceded it leaked two artifacts through into the
+shipped state: the `pr` recipe comment in `.just/gh-process.just` read
+`# PR create v6.10`, and `RELEASE_NOTES.md` carried a separate
+`### v6.10 - Complete cue-sync test matrix` section describing follow-up
+review work that never existed as its own release. The
+`.just/CHECKSUMS.json` manifest was similarly misaligned - its "latest"
+entries for `.just/cue-verify.just`, `.just/testing.just`, and
+`.just/lib/cue_sync_test.sh` pointed at intermediate branch commits
+(`dc02707`, `1f0b3c3`, `626d593`) with empty `version` strings, rather
+than the squash commit (`d499305`) that actually landed on `main`.
+
+v7.0 reconciles the labels so the version recorded for each file matches
+what actually shipped.
+
+**Changes:**
+
+- **Reverted the `pr` recipe comment** in `.just/gh-process.just` from
+  `# PR create v6.10` back to `# PR create v6.9`, undoing the spurious
+  bump. (The pr recipe logic itself is unchanged in v7.0 - this PR only
+  touches the comment text and bookkeeping.) The commit that performs
+  this revert is itself tagged `v7.0` in the regenerated manifest, so it
+  becomes the new latest checkpoint for `gh-process.just` while
+  `d499305` is recorded as the prior `v6.9` historical entry.
+- **Folded the v6.10 release notes into v6.9.** The four bullets that
+  described the cue-sync test-matrix completion (the
+  `commented_topics.toml` and `active_keys.toml` fixtures, trailing
+  newlines on the v6.9-added files, and the `SC2002` fix in
+  `cue_sync_test.sh`) all shipped inside PR #175's squash, so they belong
+  under v6.9. The standalone `### v6.10` section and its month header are
+  removed; the bullets are appended to the existing v6.9 "Changes" list.
+- **Regenerated `.just/CHECKSUMS.json`:**
+  - Dropped the orphan intermediate-branch commits (`dc02707`,
+    `1f0b3c3`, `626d593`) from the manifests for `cue-verify.just`,
+    `testing.just`, and `lib/cue_sync_test.sh`. These never reached
+    `main` and were producing misleading "latest" pointers.
+  - Retagged the surviving latest entry for each of those files to
+    point at the real main squash commit `d499305` with `version:
+    "v6.9"`, so `just checksums_verify` in derived repos resolves
+    against the commit they actually received.
+  - For `gh-process.just`, recorded this PR's commit (`80f3451`) as the
+    new `v7.0` latest entry and demoted the previous latest to a
+    historical `v6.9` entry pinned to `d499305`.
+  - Refreshed `generated_at`.
+
+No issue was filed for this work - it was a pure bookkeeping follow-up
+to PR #175's landing.
+
 ## June 2026 - cue-sync-from-github robustness fix
 
 ### v6.9 - Handle commented/missing topics & defer backup deletion (2026-06-24)
@@ -54,9 +108,6 @@ so `cue vet` passing does not prove the sync wrote anything.
   test case with both `description` and `topics` active, guarding against
   any future awk change silently breaking the pre-existing in-place
   replace behaviour.
-- Added trailing newlines to all new files added in this release
-  (`cue_sync_test.sh`, `cue-sync-tests.yml`, and the four fixtures),
-  which previously ended without a final `\n`.
 - Fixed `cat "$output" | sed ...` (SC2002) in `cue_sync_test.sh` debug
   output; `just shellcheck` flags this.
 
@@ -96,10 +147,6 @@ trailing newline:
   body carrying 4 trailing blank lines (simulating the post-round-trip
   state after a few `pr_update` cycles) and an expected output with
   those blanks stripped. Auto-discovered by `pr_body_test.sh`.
-- **Version bump** - `.just/gh-process.just` `pr` recipe comment bumped
-  from `v6.7` to `v6.8`.
-- **Checksums regenerated** - `.just/CHECKSUMS.json` updated so derived
-  repos can sync the fix via `just update_from_template`.
 
 **Related:** The v4.4 blank-line preservation fix (PR #50) correctly
 guarded blank lines *between* sections but inadvertently also preserved

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -2,32 +2,6 @@
 
 This file tracks the evolution of the Git/GitHub workflow automation module.
 
-## June 2026 - cue-sync-from-github test coverage
-
-### v6.10 - Complete cue-sync test matrix (2026-06-24)
-
-- **Related PR:** [#175](https://github.com/fini-net/template-repo/pull/175)
-
-Addresses Claude Code review feedback on the v6.9 cue-sync-from-github
-fix. The test suite added alongside the fix had two coverage gaps and
-several minor hygiene issues.
-
-**Changes:**
-
-- Added `.just/test/fixtures/cue_sync/commented_topics.toml` and a
-  corresponding test case. This is the headline fix for issue #165, yet
-  the original test matrix only covered `commented_description` -
-  `commented_topics` is the exact regression the v6.9 awk change targets.
-- Added `.just/test/fixtures/cue_sync/active_keys.toml` and a happy-path
-  test case with both `description` and `topics` active, guarding against
-  any future awk change silently breaking the pre-existing in-place
-  replace behaviour.
-- Added trailing newlines to all new files added in v6.9
-  (`cue_sync_test.sh`, `cue-sync-tests.yml`, and the four fixtures),
-  which previously ended without a final `\n`.
-- Fixed `cat "$output" | sed ...` (SC2002) in `cue_sync_test.sh` debug
-  output; `just shellcheck` flags this.
-
 ## June 2026 - cue-sync-from-github robustness fix
 
 ### v6.9 - Handle commented/missing topics & defer backup deletion (2026-06-24)
@@ -72,6 +46,19 @@ so `cue vet` passing does not prove the sync wrote anything.
   outside the existing-file branch; the verification now runs inside
   each branch (existing-file and create-new-file) so the backup
   restore logic can wrap it.
+- Added `.just/test/fixtures/cue_sync/commented_topics.toml` and a
+  corresponding test case. This is the headline fix for issue #165, yet
+  the original test matrix only covered `commented_description` -
+  `commented_topics` is the exact regression the awk change targets.
+- Added `.just/test/fixtures/cue_sync/active_keys.toml` and a happy-path
+  test case with both `description` and `topics` active, guarding against
+  any future awk change silently breaking the pre-existing in-place
+  replace behaviour.
+- Added trailing newlines to all new files added in this release
+  (`cue_sync_test.sh`, `cue-sync-tests.yml`, and the four fixtures),
+  which previously ended without a final `\n`.
+- Fixed `cat "$output" | sed ...` (SC2002) in `cue_sync_test.sh` debug
+  output; `just shellcheck` flags this.
 
 ## June 2026 - PR body trailing blank line fix
 

--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -13,7 +13,7 @@ sync:
     git pull
     git status --porcelain # stp
 
-# PR create v6.9
+# PR create v7.0
 [group('Process')]
 pr: _has_commits && pr_checks
     #!/usr/bin/env bash

--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -13,7 +13,7 @@ sync:
     git pull
     git status --porcelain # stp
 
-# PR create v6.10
+# PR create v6.9
 [group('Process')]
 pr: _has_commits && pr_checks
     #!/usr/bin/env bash


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 7️⃣ [just] gh-process v7.0 cleans up the version confusion in v6.9/v6.10
- regenerate checksums
- release notes for v7.0
- regenerate checksums

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
