### PR TITLE
🍏 [just] gh-process v7.1 installs markdownlint without npm on MacOS

### DIFF
--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-24T17:01:11Z",
+  "generated_at": "2026-06-26T00:03:58Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -178,17 +178,17 @@
 ]},
     ".just/gh-process.just": {"versions": [
         {
-          "checksum": "a6b69f79a5a9b9713c29ade4f27ebacc0b294c049a90b28ed84f226ad22dc0d5",
-          "commit": "0b9db5ffbc7c291a6503db30912c264d8b64bfcf",
-          "date": "2026-06-24T10:01:05-07:00",
-          "version": "v7.0",
+          "checksum": "0400226362a8e834a28c92bcc46b9eafd4ffb2034a800ee250e1459e8f9b06de",
+          "commit": "2106c13930aabf1f1daf26cdd5c8740d45e514e6",
+          "date": "2026-06-25T17:01:38-07:00",
+          "version": "v7.1",
           "is_latest": true
         }
 ,
         {
-          "checksum": "48851ec2d3d70fd1452f5bc67578a945366d60ffd29e07874a0ada94abbd4ee6",
-          "commit": "80f3451e2530ad38d5faa6024c4a6200315323bc",
-          "date": "2026-06-24T09:51:03-07:00",
+          "checksum": "a6b69f79a5a9b9713c29ade4f27ebacc0b294c049a90b28ed84f226ad22dc0d5",
+          "commit": "e9a87ba97c22f95538e3b6d75a4d59457f6a800a",
+          "date": "2026-06-24T10:17:54-07:00",
           "version": "v7.0",
           "is_latest": false
         }
@@ -755,11 +755,27 @@
 ]},
     ".just/lib/install-prerequisites.sh": {"versions": [
         {
+          "checksum": "7ea52aee2f07360be9e45e0a23326714d4ec042adedc25653a0c7c6a702af928",
+          "commit": "5f7c216e1b9ca7616611966c85fe54069b71c5cf",
+          "date": "2026-06-25T17:00:17-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
+          "checksum": "62779963c51592f2b3d772089371feca530338ca9de9e795ef4e63ea9a76672a",
+          "commit": "d23460902175c72058d7efc7f3a3249af06547c0",
+          "date": "2026-06-25T16:54:11-07:00",
+          "version": "",
+          "is_latest": false
+        }
+,
+        {
           "checksum": "8ad88b05b97d46b9f37a40a4a8520d6419c711effb2ad6762280260ac7d31133",
           "commit": "bf35bf743fb040da4a6f8f0d8be9ce499c564d76",
           "date": "2026-05-01T19:34:47-07:00",
           "version": "v6.5",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 ### v7.1 - Drop npm fallback for markdownlint-cli2 (2026-06-25)
 
 - **Related PR:** [#186](https://github.com/fini-net/template-repo/pull/186)
+- Fixes issue [#185](https://github.com/fini-net/template-repo/issues/185)
 
 PR #186 pinned `markdownlint-cli2` via Homebrew to satisfy Scorecard's
 Pinned-Dependencies check, but the macOS install path still fell back to
@@ -30,8 +31,6 @@ the PR's stated goal.
   when neither brew is available, since brew is uncommon on Linux and
   the hint is user-facing guidance rather than an automated fallback.
 
-No issue was filed for this follow-up; it is a scope-tightening commit
-on PR #186 itself.
 
 ## June 2026 - Version reconciliation
 

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -2,6 +2,37 @@
 
 This file tracks the evolution of the Git/GitHub workflow automation module.
 
+## June 2026 - Prerequisites brew-only pinning
+
+### v7.1 - Drop npm fallback for markdownlint-cli2 (2026-06-25)
+
+- **Related PR:** [#186](https://github.com/fini-net/template-repo/pull/186)
+
+PR #186 pinned `markdownlint-cli2` via Homebrew to satisfy Scorecard's
+Pinned-Dependencies check, but the macOS install path still fell back to
+`npm install -g markdownlint-cli2` when Homebrew was absent — an unpinned
+install that left the Scorecard warning in place. v7.1 removes the npm
+fallback so the prerequisites installer is brew-only on macOS, matching
+the PR's stated goal.
+
+**Changes:**
+
+- **Removed the npm fallback branch** in `.just/lib/install-prerequisites.sh`
+  for the macOS `markdownlint-cli2` case. The `elif command -v npm` arm
+  (with its yellow "falling back to npm (unpinned - Scorecard may still
+  warn)" message) is gone; the remaining `else` now reports "Homebrew is
+  not installed! Install Homebrew first." and points at
+  <https://brew.sh>, without suggesting Node.js as an alternative.
+- **Stripped the npm parenthetical** from the unsupported-OS install
+  hint line, which now reads `markdownlint-cli2: brew install
+  markdownlint-cli2` instead of `... (or npm install -g markdownlint-cli2)`.
+- **Linux case unchanged** — the linux branch still prints an npm hint
+  when neither brew is available, since brew is uncommon on Linux and
+  the hint is user-facing guidance rather than an automated fallback.
+
+No issue was filed for this follow-up; it is a scope-tightening commit
+on PR #186 itself.
+
 ## June 2026 - Version reconciliation
 
 ### v7.0 - Resolve v6.9/v6.10 version-label confusion (2026-06-24)

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -31,7 +31,6 @@ the PR's stated goal.
   when neither brew is available, since brew is uncommon on Linux and
   the hint is user-facing guidance rather than an automated fallback.
 
-
 ## June 2026 - Version reconciliation
 
 ### v7.0 - Resolve v6.9/v6.10 version-label confusion (2026-06-24)

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 This file tracks the evolution of the Git/GitHub workflow automation module.
 
-## June 2026 - Prerequisites brew-only pinning
+## June 2026 - Bug squash June
 
 ### v7.1 - Drop npm fallback for markdownlint-cli2 (2026-06-25)
 
@@ -30,8 +30,6 @@ the PR's stated goal.
 - **Linux case unchanged** — the linux branch still prints an npm hint
   when neither brew is available, since brew is uncommon on Linux and
   the hint is user-facing guidance rather than an automated fallback.
-
-## June 2026 - Version reconciliation
 
 ### v7.0 - Resolve v6.9/v6.10 version-label confusion (2026-06-24)
 
@@ -84,8 +82,6 @@ what actually shipped.
 
 No issue was filed for this work - it was a pure bookkeeping follow-up
 to PR #175's landing.
-
-## June 2026 - cue-sync-from-github robustness fix
 
 ### v6.9 - Handle commented/missing topics & defer backup deletion (2026-06-24)
 
@@ -140,8 +136,6 @@ so `cue vet` passing does not prove the sync wrote anything.
 - Fixed `cat "$output" | sed ...` (SC2002) in `cue_sync_test.sh` debug
   output; `just shellcheck` flags this.
 
-## June 2026 - PR body trailing blank line fix
-
 ### v6.8 - Trailing blank line accumulation fix (2026-06-23)
 
 - **Related PR:** [#174](https://github.com/fini-net/template-repo/pull/174)
@@ -181,8 +175,6 @@ trailing newline:
 guarded blank lines *between* sections but inadvertently also preserved
 the trailing-blank-line accumulation path this issue describes. The v5.8
 CRLF normalization (PR #107) is a related robustness effort.
-
-## June 2026 - Template sync robustness
 
 ### v6.7 - Fix update_from_template failures on test fixtures (2026-06-20)
 

--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -13,7 +13,7 @@ sync:
     git pull
     git status --porcelain # stp
 
-# PR create v7.0
+# PR create v7.1
 [group('Process')]
 pr: _has_commits && pr_checks
     #!/usr/bin/env bash

--- a/.just/lib/install-prerequisites.sh
+++ b/.just/lib/install-prerequisites.sh
@@ -153,18 +153,9 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 					INSTALL_FAILED+=("markdownlint-cli2")
 					echo -e "${RED}Failed to install markdownlint-cli2${NC}"
 				fi
-			elif command -v npm &>/dev/null; then
-				echo -e "${YELLOW}brew not found; falling back to npm (unpinned - Scorecard may still warn)${NC}"
-				if npm install -g markdownlint-cli2; then
-					INSTALL_SUCCESS+=("markdownlint-cli2")
-				else
-					INSTALL_FAILED+=("markdownlint-cli2")
-					echo -e "${RED}Failed to install markdownlint-cli2${NC}"
-				fi
 			else
-				echo -e "${RED}Neither brew nor npm is installed! Install Homebrew or Node.js first.${NC}"
+				echo -e "${RED}Homebrew is not installed! Install Homebrew first.${NC}"
 				echo "Install Homebrew: https://brew.sh"
-				echo "Install Node.js: brew install node"
 				INSTALL_FAILED+=("markdownlint-cli2")
 			fi
 			;;
@@ -324,7 +315,7 @@ else
 	echo "  just: https://github.com/casey/just#installation"
 	echo "  gh: https://cli.github.com/manual/installation"
 	echo "  shellcheck: https://github.com/koalaman/shellcheck#installing"
-	echo "  markdownlint-cli2: brew install markdownlint-cli2 (or npm install -g markdownlint-cli2)"
+	echo "  markdownlint-cli2: brew install markdownlint-cli2"
 	echo "  jq: https://stedolan.github.io/jq/download/"
 	echo "  gum: https://github.com/charmbracelet/gum#installation"
 	echo "  cue: https://github.com/cue-lang/cue#installation"

--- a/.just/lib/install-prerequisites.sh
+++ b/.just/lib/install-prerequisites.sh
@@ -146,15 +146,26 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 			;;
 		markdownlint-cli2)
 			echo -e "${CYAN}Installing markdownlint-cli2...${NC}"
-			if ! command -v npm &>/dev/null; then
-				echo -e "${RED}npm is not installed! Install Node.js first.${NC}"
+			if command -v brew &>/dev/null; then
+				if brew install markdownlint-cli2; then
+					INSTALL_SUCCESS+=("markdownlint-cli2")
+				else
+					INSTALL_FAILED+=("markdownlint-cli2")
+					echo -e "${RED}Failed to install markdownlint-cli2${NC}"
+				fi
+			elif command -v npm &>/dev/null; then
+				echo -e "${YELLOW}brew not found; falling back to npm (unpinned - Scorecard may still warn)${NC}"
+				if npm install -g markdownlint-cli2; then
+					INSTALL_SUCCESS+=("markdownlint-cli2")
+				else
+					INSTALL_FAILED+=("markdownlint-cli2")
+					echo -e "${RED}Failed to install markdownlint-cli2${NC}"
+				fi
+			else
+				echo -e "${RED}Neither brew nor npm is installed! Install Homebrew or Node.js first.${NC}"
+				echo "Install Homebrew: https://brew.sh"
 				echo "Install Node.js: brew install node"
 				INSTALL_FAILED+=("markdownlint-cli2")
-			elif npm install -g markdownlint-cli2; then
-				INSTALL_SUCCESS+=("markdownlint-cli2")
-			else
-				INSTALL_FAILED+=("markdownlint-cli2")
-				echo -e "${RED}Failed to install markdownlint-cli2${NC}"
 			fi
 			;;
 		jq)
@@ -269,8 +280,12 @@ elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
 			fi
 			;;
 		markdownlint-cli2)
-			echo -e "${CYAN}Install markdownlint-cli2:${NC} npm install -g markdownlint-cli2"
-			echo -e "${YELLOW}(Requires Node.js/npm)${NC}"
+			if command -v brew &>/dev/null; then
+				echo -e "${CYAN}Install markdownlint-cli2:${NC} brew install markdownlint-cli2"
+			else
+				echo -e "${CYAN}Install markdownlint-cli2:${NC} npm install -g markdownlint-cli2"
+				echo -e "${YELLOW}(Requires Node.js/npm; brew preferred when available)${NC}"
+			fi
 			;;
 		jq)
 			if [[ "$PKG_MGR" == "apt-get" ]]; then
@@ -309,7 +324,7 @@ else
 	echo "  just: https://github.com/casey/just#installation"
 	echo "  gh: https://cli.github.com/manual/installation"
 	echo "  shellcheck: https://github.com/koalaman/shellcheck#installing"
-	echo "  markdownlint-cli2: npm install -g markdownlint-cli2"
+	echo "  markdownlint-cli2: brew install markdownlint-cli2 (or npm install -g markdownlint-cli2)"
 	echo "  jq: https://stedolan.github.io/jq/download/"
 	echo "  gum: https://github.com/charmbracelet/gum#installation"
 	echo "  cue: https://github.com/cue-lang/cue#installation"


### PR DESCRIPTION
Fixes #185 

<!-- PR_BODY_DONE_START -->
## Done

- Pin markdownlint-cli2 via Homebrew to satisfy Scorecard Pinned-Dependencies
- Drop npm fallback for markdownlint-cli2 (brew-only pinning)
- Bump pr recipe to v7.1 and add release notes
- regenerate checksums
- copy edit release notes
- remove extra blank line from release notes for markdownlint
- there can be only one June in the release notes

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
