### PR TITLE
🐠 [gha] security: pin actionlint Docker image by digest

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,13 +7,7 @@
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["major", "minor", "patch"],
-      "automerge": false,
-      "minimumReleaseAge": "3 days"
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["digest"],
+      "matchUpdateTypes": ["major", "minor", "patch", "digest"],
       "automerge": false,
       "minimumReleaseAge": "3 days"
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,12 @@
       "minimumReleaseAge": "3 days"
     },
     {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest"],
+      "automerge": false,
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "matchDepNames": ["bridgecrewio/checkov-action"],
       "overrideDatasource": "git-refs",
       "overridePackageName": "https://github.com/bridgecrewio/checkov-action"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -32,6 +32,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Check workflow files
-        uses: docker://rhysd/actionlint:latest@sha256:9d36088643581e728c969f35141f88139fec77280b2be23c1f66f8e40e1025e7
+        uses: docker://rhysd/actionlint@sha256:9d36088643581e728c969f35141f88139fec77280b2be23c1f66f8e40e1025e7
         with:
           args: -color

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -32,6 +32,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Check workflow files
-        uses: docker://rhysd/actionlint@sha256:9d36088643581e728c969f35141f88139fec77280b2be23c1f66f8e40e1025e7
+        uses: docker://rhysd/actionlint:1.7.12@sha256:9d36088643581e728c969f35141f88139fec77280b2be23c1f66f8e40e1025e7  # v1.7.12
         with:
           args: -color

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -32,6 +32,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Check workflow files
-        uses: docker://rhysd/actionlint:latest
+        uses: docker://rhysd/actionlint:latest@sha256:9d36088643581e728c969f35141f88139fec77280b2be23c1f66f8e40e1025e7
         with:
           args: -color

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ go.work.sum
 # Generated repo metadata (run 'just repo_toml_generate' to regenerate)
 /.just/repo-toml.sh
 /.just/copilot_backups/
+/.claude/settings.local.json.backup
 
 # opencode
 /.opencode/plans/


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- security: pin actionlint Docker image by digest
- gitignore  .claude/settings.local.json.backup
- remove redundant :latest
- handle docker updates in github actions
- fixes for claude code review

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
