### PR TITLE
🐛 [fix] gh-process v7.2: clean_template should strip cue-sync test (closes #194)

### DIFF
--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-26T21:25:06Z",
+  "generated_at": "2026-06-26T21:27:25Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -22,11 +22,19 @@
 ]},
     ".just/clean-template.just": {"versions": [
         {
+          "checksum": "c71ced18c9359ba3055e5a2612a1859d469a292fe863d5751de824864a2be104",
+          "commit": "f2a9bdc1593cd9fd212797100e46f8a5b0edae33",
+          "date": "2026-06-26T14:26:26-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "39caf2995b8ab399f7b6852c5281d823b507242b01c5484f9a82946e2f4bc559",
           "commit": "677c6aee7587d92f1b6241a64376ecad322206c9",
           "date": "2026-06-26T13:30:40-07:00",
           "version": "",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {
@@ -754,11 +762,19 @@
 ]},
     ".just/lib/generate_checksums.sh": {"versions": [
         {
+          "checksum": "67a34b1cdaec67a4229531550537d88753deb24022b95c053dee02b6f6238b86",
+          "commit": "f2a9bdc1593cd9fd212797100e46f8a5b0edae33",
+          "date": "2026-06-26T14:26:26-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "1203ebf9c3e40a72d911b441fa8b07159258904e16f59125375982e003c3a19d",
           "commit": "677c6aee7587d92f1b6241a64376ecad322206c9",
           "date": "2026-06-26T13:30:40-07:00",
           "version": "",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-26T20:30:50Z",
+  "generated_at": "2026-06-26T21:25:06Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -920,6 +920,7 @@
     ".just/test",
     ".github/workflows/pr-body-tests.yml",
     ".github/workflows/checksums-verify.yml",
-    ".github/workflows/cue-sync-tests.yml"
+    ".github/workflows/cue-sync-tests.yml",
+    ".github/workflows/template-sync.yml"
   ]
 }

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-26T00:03:58Z",
+  "generated_at": "2026-06-26T20:30:50Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -22,11 +22,19 @@
 ]},
     ".just/clean-template.just": {"versions": [
         {
+          "checksum": "39caf2995b8ab399f7b6852c5281d823b507242b01c5484f9a82946e2f4bc559",
+          "commit": "677c6aee7587d92f1b6241a64376ecad322206c9",
+          "date": "2026-06-26T13:30:40-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "924aa3d60529da2365f293a03b98470b5e3c5c69645fb484ee48a5a5e4caae61",
           "commit": "73d9e57268ef1bdf2662ea7c5437f455128c1d1d",
           "date": "2026-03-22T20:52:08-07:00",
           "version": "",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {
@@ -178,11 +186,19 @@
 ]},
     ".just/gh-process.just": {"versions": [
         {
-          "checksum": "0400226362a8e834a28c92bcc46b9eafd4ffb2034a800ee250e1459e8f9b06de",
-          "commit": "2106c13930aabf1f1daf26cdd5c8740d45e514e6",
-          "date": "2026-06-25T17:01:38-07:00",
-          "version": "v7.1",
+          "checksum": "1eb0af09316156292d399f18bfc6a86b0ef67a08ca35739d856c1451c5677bb0",
+          "commit": "677c6aee7587d92f1b6241a64376ecad322206c9",
+          "date": "2026-06-26T13:30:40-07:00",
+          "version": "",
           "is_latest": true
+        }
+,
+        {
+          "checksum": "0400226362a8e834a28c92bcc46b9eafd4ffb2034a800ee250e1459e8f9b06de",
+          "commit": "568c76cfe3f47d4c9e8f35bc5ff7d9d58dc8f2ac",
+          "date": "2026-06-25T17:24:21-07:00",
+          "version": "v7.1",
+          "is_latest": false
         }
 ,
         {
@@ -721,20 +737,36 @@
 ]},
     ".just/lib/cue_sync_test.sh": {"versions": [
         {
+          "checksum": "cec47d5717f71f5795485b304b278923dff82e5f53f719cdebf753533e34d158",
+          "commit": "677c6aee7587d92f1b6241a64376ecad322206c9",
+          "date": "2026-06-26T13:30:40-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "08cb54a7535043a2f475fae69629312918bd5cd46a1af4cb95b5355dd1525a31",
           "commit": "d499305e2691f2601113a45003cf2dbf695f019d",
           "date": "2026-06-23T21:50:26-07:00",
           "version": "v6.9",
-          "is_latest": true
+          "is_latest": false
         }
 ]},
     ".just/lib/generate_checksums.sh": {"versions": [
+        {
+          "checksum": "1203ebf9c3e40a72d911b441fa8b07159258904e16f59125375982e003c3a19d",
+          "commit": "677c6aee7587d92f1b6241a64376ecad322206c9",
+          "date": "2026-06-26T13:30:40-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
         {
           "checksum": "03cb85d7973e998759e17f858dd6756aa69feacd35ab01dbbed0e75ba21f2bd5",
           "commit": "59271f4fede60350d8a141729fd92fe798ab710a",
           "date": "2026-06-20T14:53:57-04:00",
           "version": "v6.7",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {
@@ -756,18 +788,10 @@
     ".just/lib/install-prerequisites.sh": {"versions": [
         {
           "checksum": "7ea52aee2f07360be9e45e0a23326714d4ec042adedc25653a0c7c6a702af928",
-          "commit": "5f7c216e1b9ca7616611966c85fe54069b71c5cf",
-          "date": "2026-06-25T17:00:17-07:00",
-          "version": "",
+          "commit": "568c76cfe3f47d4c9e8f35bc5ff7d9d58dc8f2ac",
+          "date": "2026-06-25T17:24:21-07:00",
+          "version": "v7.1",
           "is_latest": true
-        }
-,
-        {
-          "checksum": "62779963c51592f2b3d772089371feca530338ca9de9e795ef4e63ea9a76672a",
-          "commit": "d23460902175c72058d7efc7f3a3249af06547c0",
-          "date": "2026-06-25T16:54:11-07:00",
-          "version": "",
-          "is_latest": false
         }
 ,
         {
@@ -892,8 +916,10 @@
     ".just/clean-template.just",
     ".just/lib/pr_body_test.sh",
     ".just/lib/template_sync_test.sh",
+    ".just/lib/cue_sync_test.sh",
     ".just/test",
     ".github/workflows/pr-body-tests.yml",
-    ".github/workflows/checksums-verify.yml"
+    ".github/workflows/checksums-verify.yml",
+    ".github/workflows/cue-sync-tests.yml"
   ]
 }

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -21,6 +21,15 @@ to `_remove_template_files` and to `CLEANED_FILES` in `generate_checksums.sh`,
 matching the existing `pr_body_test.sh` pattern. The `cue_sync_test` recipe
 itself was already removed via the wholesale `.just/testing.just` deletion.
 
+v7.2 also strips `.github/workflows/template-sync.yml`, which runs
+`just template_sync_test` — a recipe that references the now-removed
+`template_sync_test.sh`. Derived repos were left with a workflow that fails
+on every qualifying push/PR. The same `_remove_template_files` / `CLEANED_FILES`
+pattern applies. The `update_from_template` machinery
+(`.just/template-sync.just`, `.just/lib/template_update.sh`,
+`.just/lib/generate_checksums.sh`, `.just/CHECKSUMS.json`) is intentionally
+retained so derived repos can still self-update from template-repo.
+
 While touching the runner, fix `mktemp -d` at `cue_sync_test.sh:119` to use
 a portable template (`mktemp -d -t cue_sync_test.XXXXXX`) so it works on
 BSD/macOS, which require X's in the template. Flagged by Copilot in

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -4,6 +4,28 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ## June 2026 - Bug squash June
 
+### v7.2 - clean_template strips cue-sync test infra; mktemp portability (2026-06-26)
+
+- **Related issue:** [#194](https://github.com/fini-net/template-repo/issues/194)
+
+`just clean_template` already removed the PR-body test infrastructure
+(`.just/testing.just`, `.just/lib/pr_body_test.sh`, `.just/test/`, and the
+`pr-body-tests.yml` / `checksums-verify.yml` workflows) but the cue-sync test
+infra added in v6.9 (PR #175) was never added to the cleanup. Derived repos
+that ran `clean_template` shipped a dead `.just/lib/cue_sync_test.sh` runner
+whose missing-fixtures guard at line 156–160 exits 0 with "Tests skipped" —
+`just cue_sync_test` asserted nothing and went green in 9+ derived repos.
+
+v7.2 adds `.github/workflows/cue-sync-tests.yml` and `.just/lib/cue_sync_test.sh`
+to `_remove_template_files` and to `CLEANED_FILES` in `generate_checksums.sh`,
+matching the existing `pr_body_test.sh` pattern. The `cue_sync_test` recipe
+itself was already removed via the wholesale `.just/testing.just` deletion.
+
+While touching the runner, fix `mktemp -d` at `cue_sync_test.sh:119` to use
+a portable template (`mktemp -d -t cue_sync_test.XXXXXX`) so it works on
+BSD/macOS, which require X's in the template. Flagged by Copilot in
+`fini-projects#31`.
+
 ### v7.1 - Drop npm fallback for markdownlint-cli2 (2026-06-25)
 
 - **Related PR:** [#186](https://github.com/fini-net/template-repo/pull/186)

--- a/.just/clean-template.just
+++ b/.just/clean-template.just
@@ -89,6 +89,11 @@ _remove_template_files: _on_a_branch
         rm -f ".github/workflows/cue-sync-tests.yml"
     fi
 
+    if [[ -f ".github/workflows/template-sync.yml" ]]; then
+        echo "Removing .github/workflows/template-sync.yml"
+        rm -f ".github/workflows/template-sync.yml"
+    fi
+
     # Remove test scripts
     if [[ -f ".just/lib/pr_body_test.sh" ]]; then
         echo "Removing .just/lib/pr_body_test.sh"

--- a/.just/clean-template.just
+++ b/.just/clean-template.just
@@ -84,6 +84,11 @@ _remove_template_files: _on_a_branch
         rm -f ".github/workflows/checksums-verify.yml"
     fi
 
+    if [[ -f ".github/workflows/cue-sync-tests.yml" ]]; then
+        echo "Removing .github/workflows/cue-sync-tests.yml"
+        rm -f ".github/workflows/cue-sync-tests.yml"
+    fi
+
     # Remove test scripts
     if [[ -f ".just/lib/pr_body_test.sh" ]]; then
         echo "Removing .just/lib/pr_body_test.sh"
@@ -93,6 +98,11 @@ _remove_template_files: _on_a_branch
     if [[ -f ".just/lib/template_sync_test.sh" ]]; then
         echo "Removing .just/lib/template_sync_test.sh"
         rm -f ".just/lib/template_sync_test.sh"
+    fi
+
+    if [[ -f ".just/lib/cue_sync_test.sh" ]]; then
+        echo "Removing .just/lib/cue_sync_test.sh"
+        rm -f ".just/lib/cue_sync_test.sh"
     fi
 
     # Remove this cleanup script after use

--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -13,7 +13,7 @@ sync:
     git pull
     git status --porcelain # stp
 
-# PR create v7.1
+# PR create v7.2
 [group('Process')]
 pr: _has_commits && pr_checks
     #!/usr/bin/env bash

--- a/.just/lib/cue_sync_test.sh
+++ b/.just/lib/cue_sync_test.sh
@@ -116,7 +116,7 @@ run_test() {
     fi
 
     local workspace
-    workspace=$(mktemp -d)
+    workspace=$(mktemp -d -t cue_sync_test.XXXXXX)
     cp "$fixture_path" "$workspace/.repo.toml"
 
     local output="$workspace/out.toml"

--- a/.just/lib/generate_checksums.sh
+++ b/.just/lib/generate_checksums.sh
@@ -25,6 +25,7 @@ CLEANED_FILES=(
 	".github/workflows/pr-body-tests.yml"
 	".github/workflows/checksums-verify.yml"
 	".github/workflows/cue-sync-tests.yml"
+	".github/workflows/template-sync.yml"
 )
 
 # Get list of all .just/*.just files

--- a/.just/lib/generate_checksums.sh
+++ b/.just/lib/generate_checksums.sh
@@ -20,9 +20,11 @@ CLEANED_FILES=(
 	".just/clean-template.just"
 	".just/lib/pr_body_test.sh"
 	".just/lib/template_sync_test.sh"
+	".just/lib/cue_sync_test.sh"
 	".just/test"
 	".github/workflows/pr-body-tests.yml"
 	".github/workflows/checksums-verify.yml"
+	".github/workflows/cue-sync-tests.yml"
 )
 
 # Get list of all .just/*.just files


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🐛 [fix] clean_template should strip cue-sync test infra + mktemp portability (closes #194)
- 🧪 [chore] regenerate CHECKSUMS.json for v7.2
- remove .github/workflows/template-sync.yml during cleaning
- regenerate checksums

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
