### PR TITLE
🐛 [just] gh-process v7.6 guard gh-observer detection when gh absent

### DIFF
--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-28T16:31:02Z",
+  "generated_at": "2026-06-28T16:38:48Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -202,11 +202,19 @@
 ]},
     ".just/gh-process.just": {"versions": [
         {
+          "checksum": "a4ebd70e88fa7d96cf5d17c180f16918b898e63d097ec36f85ae69a25decf478",
+          "commit": "b604c5c4ccb5b03d1d522dce5e8ae2f5c0ccdca2",
+          "date": "2026-06-28T09:38:42-07:00",
+          "version": "v6.7",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "38639dfbc41f3e332a9e33a5bb4535df24b7aa95612e5a03ec3e16369a022e9c",
           "commit": "94e6a2a58c9a01e862f3988f57b4bd0664ecf7fd",
           "date": "2026-06-28T09:14:11-07:00",
           "version": "v7.5",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-28T16:38:48Z",
+  "generated_at": "2026-06-28T16:43:28Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-28T16:00:25Z",
+  "generated_at": "2026-06-28T16:31:02Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -203,18 +203,10 @@
     ".just/gh-process.just": {"versions": [
         {
           "checksum": "38639dfbc41f3e332a9e33a5bb4535df24b7aa95612e5a03ec3e16369a022e9c",
-          "commit": "8c788f7c64dc51aee52dc8168a898bd721bc60b7",
-          "date": "2026-06-28T09:00:07-07:00",
-          "version": "",
-          "is_latest": true
-        }
-,
-        {
-          "checksum": "98acbd5f9ed752b1f2ea89b106de8b4036b4360286d77045d0ba865be4633b36",
-          "commit": "49de3bcd2a8f62de8f01afd06740e7a11aaa75fa",
-          "date": "2026-06-28T15:48:11Z",
+          "commit": "94e6a2a58c9a01e862f3988f57b4bd0664ecf7fd",
+          "date": "2026-06-28T09:14:11-07:00",
           "version": "v7.5",
-          "is_latest": false
+          "is_latest": true
         }
 ,
         {
@@ -867,11 +859,19 @@
 ]},
     ".just/lib/install-prerequisites.sh": {"versions": [
         {
+          "checksum": "badd72e8de8d4e843e7d3a4b51362e759d67063fe26f9714e3e8ae7238b65bbb",
+          "commit": "ebefbcf5b59f64bc71b9dba434d9e4a7029b4686",
+          "date": "2026-06-28T09:27:48-07:00",
+          "version": "v7.6",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "7ea52aee2f07360be9e45e0a23326714d4ec042adedc25653a0c7c6a702af928",
           "commit": "568c76cfe3f47d4c9e8f35bc5ff7d9d58dc8f2ac",
           "date": "2026-06-25T17:24:21-07:00",
           "version": "v7.1",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -4,6 +4,24 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ## June 2026 - Bug squash June
 
+### v7.6 - guard gh-observer detection when gh absent (2026-06-28)
+
+- **Related issue:** [#201](https://github.com/fini-net/template-repo/issues/201)
+
+`.just/lib/install-prerequisites.sh:75` ran `gh extension list` to detect
+`gh-observer` without first verifying that `gh` itself was installed. The
+top-level `gh` guard at line 39 only covered the `gh` tool detection
+block, leaving the `gh-observer` detection at line 75 unguarded. On a
+system without `gh`, the scan emitted a `command not found` error
+(despite the `2>/dev/null` redirection, which only suppresses stderr
+from `gh`, not the shell's own "command not found" message for a missing
+binary).
+
+v7.6 adds a `command -v gh &>/dev/null &&` guard to the `gh-observer`
+detection block. When `gh` is absent, `gh-observer` now falls cleanly
+into the `MISSING` list instead of producing noisy errors, matching the
+behavior of every other tool in the scan.
+
 ### v7.5 - skip workflow watcher in pr_checks when repo has no workflows (2026-06-28)
 
 - **Related PR:** [#211](https://github.com/fini-net/template-repo/pull/211)

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ### v7.6 - guard gh-observer detection when gh absent (2026-06-28)
 
+- **Related PR:** [#211](https://github.com/fini-net/template-repo/pull/212)
 - **Related issue:** [#201](https://github.com/fini-net/template-repo/issues/201)
 
 `.just/lib/install-prerequisites.sh:75` ran `gh extension list` to detect

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -6,7 +6,7 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ### v7.6 - guard gh-observer detection when gh absent (2026-06-28)
 
-- **Related PR:** [#211](https://github.com/fini-net/template-repo/pull/212)
+- **Related PR:** [#212](https://github.com/fini-net/template-repo/pull/212)
 - **Related issue:** [#201](https://github.com/fini-net/template-repo/issues/201)
 
 `.just/lib/install-prerequisites.sh:75` ran `gh extension list` to detect

--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -13,7 +13,7 @@ sync:
     git pull
     git status --porcelain # stp
 
-# PR create v7.5
+# PR create v7.6
 [group('Process')]
 pr: _has_commits && pr_checks
     #!/usr/bin/env bash

--- a/.just/lib/install-prerequisites.sh
+++ b/.just/lib/install-prerequisites.sh
@@ -72,7 +72,7 @@ else
 	MISSING+=("cue")
 fi
 
-if gh extension list 2>/dev/null | grep -q 'gh-observer'; then
+if command -v gh &>/dev/null && gh extension list 2>/dev/null | grep -q 'gh-observer'; then
 	INSTALLED+=("gh-observer")
 else
 	MISSING+=("gh-observer")


### PR DESCRIPTION
Fixes #201 

<!-- PR_BODY_DONE_START -->
## Done

- 🐛 [just] gh-process v7.6 guard gh-observer detection when gh absent
- regenerate checksums
- bump to v6.7
- regenerate checksums
- bump to v7.6
- regenerate checksums
- correct PR reference

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
