### PR TITLE
🛀 [just] gh-process v7.7 uses awk with full safety checks

### DIFF
--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-28T16:43:28Z",
+  "generated_at": "2026-06-28T18:05:38Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -145,11 +145,19 @@
 ]},
     ".just/cue-verify.just": {"versions": [
         {
+          "checksum": "e6a849dffe303feb53ca8258b0f3eb1abb11a767e91da5f25b99b3940aaabc24",
+          "commit": "20b30a22d8d658f3d44645648399e571a6c39c4f",
+          "date": "2026-06-28T11:05:33-07:00",
+          "version": "v7.7",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "553f938f4f904a16d7b9f8a87e872001f0306bb9c2344d2c30c43d8297fb3af1",
           "commit": "d499305e2691f2601113a45003cf2dbf695f019d",
           "date": "2026-06-23T21:50:26-07:00",
           "version": "v6.9",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {
@@ -202,11 +210,19 @@
 ]},
     ".just/gh-process.just": {"versions": [
         {
-          "checksum": "a4ebd70e88fa7d96cf5d17c180f16918b898e63d097ec36f85ae69a25decf478",
-          "commit": "b604c5c4ccb5b03d1d522dce5e8ae2f5c0ccdca2",
-          "date": "2026-06-28T09:38:42-07:00",
-          "version": "v6.7",
+          "checksum": "f9e6d7973210712250d6fbbca2bf3e0f35dc3669f0dc85b42deed9a63920f632",
+          "commit": "20b30a22d8d658f3d44645648399e571a6c39c4f",
+          "date": "2026-06-28T11:05:33-07:00",
+          "version": "v7.7",
           "is_latest": true
+        }
+,
+        {
+          "checksum": "a4ebd70e88fa7d96cf5d17c180f16918b898e63d097ec36f85ae69a25decf478",
+          "commit": "f2299dbedabf38f57521a29198e6916682c0ddf2",
+          "date": "2026-06-28T10:34:20-07:00",
+          "version": "v7.6",
+          "is_latest": false
         }
 ,
         {
@@ -868,8 +884,8 @@
     ".just/lib/install-prerequisites.sh": {"versions": [
         {
           "checksum": "badd72e8de8d4e843e7d3a4b51362e759d67063fe26f9714e3e8ae7238b65bbb",
-          "commit": "ebefbcf5b59f64bc71b9dba434d9e4a7029b4686",
-          "date": "2026-06-28T09:27:48-07:00",
+          "commit": "f2299dbedabf38f57521a29198e6916682c0ddf2",
+          "date": "2026-06-28T10:34:20-07:00",
           "version": "v7.6",
           "is_latest": true
         }

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ### v7.7 - fix errexit bypass in cue-sync-from-github (2026-06-28)
 
+- **Related PR:** [#213](https://github.com/fini-net/template-repo/pull/213)
 - **Related issue:** [#197](https://github.com/fini-net/template-repo/issues/197)
 
 The `cue-sync-from-github` recipe wrote its awk output via

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -4,6 +4,23 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ## June 2026 - Bug squash June
 
+### v7.7 - fix errexit bypass in cue-sync-from-github (2026-06-28)
+
+- **Related issue:** [#197](https://github.com/fini-net/template-repo/issues/197)
+
+The `cue-sync-from-github` recipe wrote its awk output via
+`awk ... > .repo.toml.tmp && mv .repo.toml.tmp .repo.toml`
+at `.just/cue-verify.just:233`. The script runs under `set -euo pipefail`,
+but commands in a `&&` list are exempt from errexit — so if `awk` failed,
+the failure was swallowed and the recipe continued with the stale
+`.repo.toml`, proceeding to the `cue vet` and `just cue-verify` stages
+unexpectedly. This undermined the two-stage validation that v6.9 added
+specifically to catch silent sync failures.
+
+v7.7 splits the `&&`-joined line into two separate commands so `set -e`
+behaves as intended: if `awk` exits non-zero, the recipe aborts
+immediately and `mv` is skipped, leaving the backup/restore path intact.
+
 ### v7.6 - guard gh-observer detection when gh absent (2026-06-28)
 
 - **Related PR:** [#212](https://github.com/fini-net/template-repo/pull/212)

--- a/.just/cue-verify.just
+++ b/.just/cue-verify.just
@@ -230,7 +230,8 @@ cue-sync-from-github:
                 }
                 flush_blanks()
             }
-        ' .repo.toml > .repo.toml.tmp && mv .repo.toml.tmp .repo.toml
+        ' .repo.toml > .repo.toml.tmp
+        mv .repo.toml.tmp .repo.toml
 
         # Validate the TOML is still valid after modification.
         # NOTE: cue vet passing does NOT prove the sync wrote the right values

--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -13,7 +13,7 @@ sync:
     git pull
     git status --porcelain # stp
 
-# PR create v7.6
+# PR create v7.7
 [group('Process')]
 pr: _has_commits && pr_checks
     #!/usr/bin/env bash


### PR DESCRIPTION
Fixes #197 

<!-- PR_BODY_DONE_START -->
## Done

- 🛀 [just] v7.7 uses awk with full safety checks
- regenerate checksums
- note PR #213 in release notes

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
