### PR TITLE
🐛 [just] gh-process v7.8 fail on malformed web_url in repo_toml_generate

### DIFF
--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-28T23:48:58Z",
+  "generated_at": "2026-06-28T23:52:02Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -211,7 +211,7 @@
     ".just/gh-process.just": {"versions": [
         {
           "checksum": "984150959f84ef6579fbc0a284e0f28c6de98584d4155ddff3110f20728593d6",
-          "commit": "20b5afebc94ae075f54e9204bfd22817ca82483d",
+          "commit": "1b34432209e76151a4495306146aa5349e525844",
           "date": "2026-06-28T16:48:54-07:00",
           "version": "v7.8",
           "is_latest": true
@@ -653,7 +653,7 @@
     ".just/repo-toml.just": {"versions": [
         {
           "checksum": "6060399855846b961da5e6550bfa0c9740afaf7962eb97530588e826af9a3091",
-          "commit": "20b5afebc94ae075f54e9204bfd22817ca82483d",
+          "commit": "1b34432209e76151a4495306146aa5349e525844",
           "date": "2026-06-28T16:48:54-07:00",
           "version": "v7.8",
           "is_latest": true

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-28T18:05:38Z",
+  "generated_at": "2026-06-28T23:48:58Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -146,8 +146,8 @@
     ".just/cue-verify.just": {"versions": [
         {
           "checksum": "e6a849dffe303feb53ca8258b0f3eb1abb11a767e91da5f25b99b3940aaabc24",
-          "commit": "20b30a22d8d658f3d44645648399e571a6c39c4f",
-          "date": "2026-06-28T11:05:33-07:00",
+          "commit": "d983643223de5ce240010f360fa8d824354b68cf",
+          "date": "2026-06-28T14:14:02-07:00",
           "version": "v7.7",
           "is_latest": true
         }
@@ -210,11 +210,19 @@
 ]},
     ".just/gh-process.just": {"versions": [
         {
-          "checksum": "f9e6d7973210712250d6fbbca2bf3e0f35dc3669f0dc85b42deed9a63920f632",
-          "commit": "20b30a22d8d658f3d44645648399e571a6c39c4f",
-          "date": "2026-06-28T11:05:33-07:00",
-          "version": "v7.7",
+          "checksum": "984150959f84ef6579fbc0a284e0f28c6de98584d4155ddff3110f20728593d6",
+          "commit": "20b5afebc94ae075f54e9204bfd22817ca82483d",
+          "date": "2026-06-28T16:48:54-07:00",
+          "version": "v7.8",
           "is_latest": true
+        }
+,
+        {
+          "checksum": "f9e6d7973210712250d6fbbca2bf3e0f35dc3669f0dc85b42deed9a63920f632",
+          "commit": "d983643223de5ce240010f360fa8d824354b68cf",
+          "date": "2026-06-28T14:14:02-07:00",
+          "version": "v7.7",
+          "is_latest": false
         }
 ,
         {
@@ -644,11 +652,19 @@
 ]},
     ".just/repo-toml.just": {"versions": [
         {
+          "checksum": "6060399855846b961da5e6550bfa0c9740afaf7962eb97530588e826af9a3091",
+          "commit": "20b5afebc94ae075f54e9204bfd22817ca82483d",
+          "date": "2026-06-28T16:48:54-07:00",
+          "version": "v7.8",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "58fa8830111fd65a8c8e25409b57395c1df76109365115d3895c2db7e1100bfa",
           "commit": "eb298fa0258c406fbfdd3b1ab3b4d18f6e8efdad",
           "date": "2026-04-23T13:36:50-07:00",
           "version": "v6.1",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -4,6 +4,47 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ## June 2026 - Bug squash June
 
+### v7.8 - fail on malformed web_url in repo_toml_generate (2026-06-28)
+
+- Fixes issue [#200](https://github.com/fini-net/template-repo/issues/200)
+
+`repo_toml_generate` derived `ORG_NAME` and `REPO_NAME` from `WEB_URL`
+via two `sed -E` substitutions at `.just/repo-toml.just:43-44`. On a
+no-match, `sed` echoes the input through unchanged, so the subsequent
+`-z` validation at lines 47-52 could not catch malformed `web_url`
+values: `not-a-url` passed through unchanged (non-empty, so `-z` was
+happy) and produced garbage derived names, while
+`https://github.com/org/repo/extra` silently dropped the trailing
+segment and produced a wrong `REPO_NAME`.
+
+v7.8 replaces the sed calls and the `-z` guard with a single bash
+regex match:
+
+```bash
+if [[ "$WEB_URL_RAW" =~ ^https://github\.com/([^/]+)/([^/]+)$ ]]; then
+    ORG_NAME="${BASH_REMATCH[1]}"
+    REPO_NAME="${BASH_REMATCH[2]}"
+else
+    echo "Error: web_url does not match expected format"
+    exit 1
+fi
+```
+
+This mirrors the cue schema at `docs/repo-toml.cue:24`
+(`^https://github\\.com/[^/]+/[^/]+$`) as defense-in-depth: `cue vet`
+runs earlier in the recipe (lines 20-24) and would already reject most
+malformed values, but the extraction now fails explicitly on the same
+pattern so a future schema loosening or a bypassed cue stage can't
+silently produce garbage.
+
+The strict match rejects:
+
+- Missing scheme / wrong host (`not-a-url`, `http://example.com/o/r`)
+- Bare host or empty org/repo (`https://github.com/`, `https://github.com/org`)
+- Extra path segments (`https://github.com/org/repo/extra`)
+- Trailing slash (`https://github.com/org/repo/`)
+- Empty string
+
 ### v7.7 - fix errexit bypass in cue-sync-from-github (2026-06-28)
 
 - **Related PR:** [#213](https://github.com/fini-net/template-repo/pull/213)

--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -13,7 +13,7 @@ sync:
     git pull
     git status --porcelain # stp
 
-# PR create v7.7
+# PR create v7.8
 [group('Process')]
 pr: _has_commits && pr_checks
     #!/usr/bin/env bash

--- a/.just/repo-toml.just
+++ b/.just/repo-toml.just
@@ -38,15 +38,20 @@ repo_toml_generate:
 
     # Derive org and repo name from web URL
     # Example: https://github.com/fini-net/template-repo -> fini-net, template-repo
-    # Extract raw URL separately from @sh-quoted version to avoid fragile sed stripping
+    # Extract raw URL separately from @sh-quoted version to avoid @sh quoting
     WEB_URL_RAW=$(echo "$JSON" | jq -r '.urls.web_url // ""')
-    ORG_NAME=$(echo "$WEB_URL_RAW" | sed -E 's|https://github.com/([^/]+)/.*|\1|')
-    REPO_NAME=$(echo "$WEB_URL_RAW" | sed -E 's|https://github.com/[^/]+/(.+)|\1|')
 
-    # Validate URL parsing succeeded
-    if [[ -z "$ORG_NAME" ]] || [[ -z "$REPO_NAME" ]]; then
-        echo "{{RED}}Error: Failed to parse organization and repository name from web_url{{NORMAL}}"
-        echo "{{YELLOW}}Expected format: https://github.com/org-name/repo-name{{NORMAL}}"
+    # Strict match: exactly https://github.com/<org>/<repo>, nothing after.
+    # sed-based extraction passed input through unchanged on no-match, so
+    # malformed web_url values silently produced garbage ORG_NAME/REPO_NAME
+    # and slipped past the -z guard. A bash regex match fails explicitly
+    # instead. Mirrors the cue schema at docs/repo-toml.cue.
+    if [[ "$WEB_URL_RAW" =~ ^https://github\.com/([^/]+)/([^/]+)$ ]]; then
+        ORG_NAME="${BASH_REMATCH[1]}"
+        REPO_NAME="${BASH_REMATCH[2]}"
+    else
+        echo "{{RED}}Error: web_url does not match expected format{{NORMAL}}"
+        echo "{{YELLOW}}Expected: https://github.com/org-name/repo-name{{NORMAL}}"
         echo "{{YELLOW}}Got: $WEB_URL_RAW{{NORMAL}}"
         exit 1
     fi


### PR DESCRIPTION
Fixes #200 

<!-- PR_BODY_DONE_START -->
## Done

- 🐛 [just] gh-process v7.8 fail on malformed web_url in repo_toml_generate
- regenerate checksums

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
