### PR TITLE
🩹 [just] gh-process v8.1 fix awk backslash mangling in cue-sync

### DIFF
--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-29T18:28:34Z",
+  "generated_at": "2026-06-29T18:56:03Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -153,11 +153,19 @@
 ]},
     ".just/cue-verify.just": {"versions": [
         {
+          "checksum": "647c1a5e32d206a08ca0f2366e164e4beb85ebb67f5a25920869015f1560b9f5",
+          "commit": "1e7b944643ac1f2ecdc2ddddc1bbf0b73cb4a57d",
+          "date": "2026-06-29T11:49:43-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "a2ee3ac14833d1c07050689d142db031bd0ee48fc98607e0a551ccd7a1afe557",
           "commit": "cab18c14eac6fcb0bf7b67d01ac6d4bd96c5d014",
           "date": "2026-06-29T10:53:52-07:00",
           "version": "v8.1",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {
@@ -889,11 +897,19 @@
 ]},
     ".just/lib/cue_sync_test.sh": {"versions": [
         {
+          "checksum": "32860611ecb4475bcebd4865b94fed4fd559e79ba13cfcce6dfbcf21fb1dde36",
+          "commit": "1e7b944643ac1f2ecdc2ddddc1bbf0b73cb4a57d",
+          "date": "2026-06-29T11:49:43-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "1128d68d8694cfdce3a60e9a209769d99b35f275da6d67d17cbdae7bb1347586",
           "commit": "cab18c14eac6fcb0bf7b67d01ac6d4bd96c5d014",
           "date": "2026-06-29T10:53:52-07:00",
           "version": "v8.1",
-          "is_latest": true
+          "is_latest": false
         }
 ,
         {
@@ -930,11 +946,19 @@
 ]},
     ".just/lib/cue_sync.awk": {"versions": [
         {
+          "checksum": "13754398397699df8019710be9a074005f51e275e33d627381705e1f7a8b34ec",
+          "commit": "1e7b944643ac1f2ecdc2ddddc1bbf0b73cb4a57d",
+          "date": "2026-06-29T11:49:43-07:00",
+          "version": "",
+          "is_latest": true
+        }
+,
+        {
           "checksum": "b7c0743c90676dc53956e3f67636619157731a293f0328fd3398fadc76cd4168",
           "commit": "ce09d6fede10d6423e875e943d6a4f8220f9dd66",
           "date": "2026-06-29T10:40:02-07:00",
           "version": "v8.0",
-          "is_latest": true
+          "is_latest": false
         }
 ]},
     ".just/lib/generate_checksums.sh": {"versions": [

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-29T17:36:50Z",
+  "generated_at": "2026-06-29T17:53:54Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [
@@ -153,11 +153,19 @@
 ]},
     ".just/cue-verify.just": {"versions": [
         {
-          "checksum": "dbfeb1651f804e079e81a8aaa66df6571fee49f682eff095e13d3ae94e1199b5",
-          "commit": "dd21f6f05aef92b135af7547796251316cb6a946",
-          "date": "2026-06-29T10:16:33-07:00",
-          "version": "v8.0",
+          "checksum": "a2ee3ac14833d1c07050689d142db031bd0ee48fc98607e0a551ccd7a1afe557",
+          "commit": "cab18c14eac6fcb0bf7b67d01ac6d4bd96c5d014",
+          "date": "2026-06-29T10:53:52-07:00",
+          "version": "v8.1",
           "is_latest": true
+        }
+,
+        {
+          "checksum": "dbfeb1651f804e079e81a8aaa66df6571fee49f682eff095e13d3ae94e1199b5",
+          "commit": "ce09d6fede10d6423e875e943d6a4f8220f9dd66",
+          "date": "2026-06-29T10:40:02-07:00",
+          "version": "v8.0",
+          "is_latest": false
         }
 ,
         {
@@ -226,11 +234,19 @@
 ]},
     ".just/gh-process.just": {"versions": [
         {
-          "checksum": "9274ee10ffc74ac3b3b343b436318a040c0fb69d193d2ef0b441780b77e8c374",
-          "commit": "dd21f6f05aef92b135af7547796251316cb6a946",
-          "date": "2026-06-29T10:16:33-07:00",
-          "version": "v8.0",
+          "checksum": "38ef8c4b50e47506464564c440cc914c6eb6f42b4a9e8714bf3b4496fdb714ad",
+          "commit": "cab18c14eac6fcb0bf7b67d01ac6d4bd96c5d014",
+          "date": "2026-06-29T10:53:52-07:00",
+          "version": "v8.1",
           "is_latest": true
+        }
+,
+        {
+          "checksum": "9274ee10ffc74ac3b3b343b436318a040c0fb69d193d2ef0b441780b77e8c374",
+          "commit": "ce09d6fede10d6423e875e943d6a4f8220f9dd66",
+          "date": "2026-06-29T10:40:02-07:00",
+          "version": "v8.0",
+          "is_latest": false
         }
 ,
         {
@@ -873,11 +889,19 @@
 ]},
     ".just/lib/cue_sync_test.sh": {"versions": [
         {
-          "checksum": "ac5f0fa428b403564a7f0e0897e0145f356f01bc4dfd4a11056caa2d35da0a1c",
-          "commit": "dd21f6f05aef92b135af7547796251316cb6a946",
-          "date": "2026-06-29T10:16:33-07:00",
-          "version": "v8.0",
+          "checksum": "1128d68d8694cfdce3a60e9a209769d99b35f275da6d67d17cbdae7bb1347586",
+          "commit": "cab18c14eac6fcb0bf7b67d01ac6d4bd96c5d014",
+          "date": "2026-06-29T10:53:52-07:00",
+          "version": "v8.1",
           "is_latest": true
+        }
+,
+        {
+          "checksum": "ac5f0fa428b403564a7f0e0897e0145f356f01bc4dfd4a11056caa2d35da0a1c",
+          "commit": "ce09d6fede10d6423e875e943d6a4f8220f9dd66",
+          "date": "2026-06-29T10:40:02-07:00",
+          "version": "v8.0",
+          "is_latest": false
         }
 ,
         {
@@ -907,25 +931,17 @@
     ".just/lib/cue_sync.awk": {"versions": [
         {
           "checksum": "b7c0743c90676dc53956e3f67636619157731a293f0328fd3398fadc76cd4168",
-          "commit": "3cffa04b5430e3345994653e96eb0ea999e5905b",
-          "date": "2026-06-29T10:32:30-07:00",
-          "version": "",
-          "is_latest": true
-        }
-,
-        {
-          "checksum": "3f29e4d02799815fd74d4f283b735fb78df82b5b8f4be814ec210233ceeb7583",
-          "commit": "dd21f6f05aef92b135af7547796251316cb6a946",
-          "date": "2026-06-29T10:16:33-07:00",
+          "commit": "ce09d6fede10d6423e875e943d6a4f8220f9dd66",
+          "date": "2026-06-29T10:40:02-07:00",
           "version": "v8.0",
-          "is_latest": false
+          "is_latest": true
         }
 ]},
     ".just/lib/generate_checksums.sh": {"versions": [
         {
           "checksum": "a325886ba9b095ccfac8add9748ab177ca66685d26b0a422110c2788a7b5089a",
-          "commit": "dd21f6f05aef92b135af7547796251316cb6a946",
-          "date": "2026-06-29T10:16:33-07:00",
+          "commit": "ce09d6fede10d6423e875e943d6a4f8220f9dd66",
+          "date": "2026-06-29T10:40:02-07:00",
           "version": "v8.0",
           "is_latest": true
         }

--- a/.just/CHECKSUMS.json
+++ b/.just/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-06-29T17:53:54Z",
+  "generated_at": "2026-06-29T18:28:34Z",
   "template_repo": "https://github.com/fini-net/template-repo",
   "files": {
     ".just/claude.just": {"versions": [

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -18,9 +18,26 @@ the trailing `cue-verify` then detected a mismatch against the GitHub
 API, restored the backup, and exited 1 — leaving sync permanently
 broken for any repo with a backslash in its description.
 
-v8.1 double-escapes backslashes before the quote-escape step so awk's
-`-v` un-escapes them back to single backslashes, and the TOML writer
-sees the original value.
+The initial fix double-escaped backslashes before the quote-escape
+step so awk's `-v` un-escaped them back to single backslashes. That
+prevented the mangling but produced **invalid TOML** — a raw
+`description = "C:\path"` contains an illegal `\p` escape, so
+`cue vet` failed on the modified file and the sync still broke. The
+same unescaped write also affected the else branch that creates a
+new `.repo.toml` from scratch, where there was no previous file to
+restore from, so the failure was permanent on first-time sync.
+
+v8.1 moves the contract to its root: the description is passed to
+awk via the environment (`desc=...`), not `-v`, so no escape
+processing happens before the program runs. The awk program itself
+applies TOML-escaping (`\`→`\\`, `"`→`\"`) on emit via a new
+`toml_escape()` helper, so the output is valid TOML regardless of
+the description's contents. The else branch that bootstraps a new
+`.repo.toml` mirrors the same escape in shell before `printf`. The
+mirrored escape step in the test runner (`cue_sync_test.sh`) is
+gone — both paths now pass the raw description and let awk own the
+escaping. `ENVIRON` is POSIX awk, supported by gawk, mawk, nawk,
+and busybox awk on all target platforms.
 
 ### v8.0 - extract shared `cue_sync.awk` (2026-06-29)
 

--- a/.just/RELEASE_NOTES.md
+++ b/.just/RELEASE_NOTES.md
@@ -4,6 +4,24 @@ This file tracks the evolution of the Git/GitHub workflow automation module.
 
 ## June 2026 - Bug squash June
 
+### v8.1 - fix awk backslash mangling in cue-sync (2026-06-29)
+
+- Fixes issue [#198](https://github.com/fini-net/template-repo/issues/198)
+
+`cue-sync-from-github` escaped the GitHub description for TOML but
+passed the result to awk via `-v desc=...`. awk's `-v` assignment
+processes backslash escape sequences before the program runs, so any
+backslash in a repo description (Windows paths, regexes, prose) was
+silently mangled — `C:\path\to\thing` became `C:athothing`. The
+resulting TOML was structurally valid, so `cue vet` didn't catch it;
+the trailing `cue-verify` then detected a mismatch against the GitHub
+API, restored the backup, and exited 1 — leaving sync permanently
+broken for any repo with a backslash in its description.
+
+v8.1 double-escapes backslashes before the quote-escape step so awk's
+`-v` un-escapes them back to single backslashes, and the TOML writer
+sees the original value.
+
 ### v8.0 - extract shared `cue_sync.awk` (2026-06-29)
 
 - Fixes issue [#196](https://github.com/fini-net/template-repo/issues/196)

--- a/.just/cue-verify.just
+++ b/.just/cue-verify.just
@@ -188,14 +188,6 @@ cue-sync-from-github:
         cp .repo.toml .repo.toml.backup
         echo "{{YELLOW}}Created backup: .repo.toml.backup{{NORMAL}}"
 
-        # Update .repo.toml using awk (portable across macOS and Linux)
-        # Double-escape backslashes BEFORE the quote-escape step: awk's `-v`
-        # assignment processes backslash escape sequences (\n, \t, \p -> p)
-        # before the program runs, so a single backslash in the GitHub
-        # description would be silently mangled. See issue #198.
-        GH_DESC_ESCAPED="${GH_DESC//\\/\\\\}"
-        GH_DESC_ESCAPED="${GH_DESC_ESCAPED//\"/\\\"}"
-
         # The state-aware awk program lives in .just/lib/cue_sync.awk so the
         # test runner (.just/lib/cue_sync_test.sh) invokes the exact same
         # logic. See issue #196 for why the program is no longer inlined.
@@ -208,7 +200,14 @@ cue-sync-from-github:
         # landing adjacent to the preceding key (e.g. `license`) rather than
         # visually attaching to the next `[section]`. See issue #165 for the
         # failure modes this addresses.
-        awk -v desc="$GH_DESC_ESCAPED" -v topics="[$TOPICS_TOML]" \
+        #
+        # Description is passed via the environment (desc=...), not awk's -v,
+        # because -v processes backslash escape sequences before the program
+        # runs, which would mangle backslashes in the GitHub description. The
+        # awk program applies TOML-escaping (backslash and double-quote) on
+        # emit, so the output is valid TOML regardless of the description's
+        # contents. See issue #198.
+        desc="$GH_DESC" awk -v topics="[$TOPICS_TOML]" \
             -f .just/lib/cue_sync.awk .repo.toml > .repo.toml.tmp
         mv .repo.toml.tmp .repo.toml
 
@@ -241,11 +240,19 @@ cue-sync-from-github:
         GIT_SSH="git@github.com:$ORG_NAME/$REPO_NAME.git"
         WEB_URL="https://github.com/$ORG_NAME/$REPO_NAME"
 
+        # TOML-escape the description for the new file: backslash -> \\ and
+        # double-quote -> \". Without this, a description containing a
+        # backslash (e.g. `C:\path`) produces invalid TOML and cue vet fails,
+        # leaving the repo unable to bootstrap .repo.toml on first sync.
+        # See issue #198.
+        GH_DESC_TOML="${GH_DESC//\\/\\\\}"
+        GH_DESC_TOML="${GH_DESC_TOML//\"/\\\"}"
+
         printf '%s\n' \
             "# .repo.toml" \
             "" \
             "[about]" \
-            "description = \"$GH_DESC\"" \
+            "description = \"$GH_DESC_TOML\"" \
             "topics = [$TOPICS_TOML]" \
             "" \
             "[urls]" \

--- a/.just/cue-verify.just
+++ b/.just/cue-verify.just
@@ -189,7 +189,12 @@ cue-sync-from-github:
         echo "{{YELLOW}}Created backup: .repo.toml.backup{{NORMAL}}"
 
         # Update .repo.toml using awk (portable across macOS and Linux)
-        GH_DESC_ESCAPED="${GH_DESC//\"/\\\"}"
+        # Double-escape backslashes BEFORE the quote-escape step: awk's `-v`
+        # assignment processes backslash escape sequences (\n, \t, \p -> p)
+        # before the program runs, so a single backslash in the GitHub
+        # description would be silently mangled. See issue #198.
+        GH_DESC_ESCAPED="${GH_DESC//\\/\\\\}"
+        GH_DESC_ESCAPED="${GH_DESC_ESCAPED//\"/\\\"}"
 
         # The state-aware awk program lives in .just/lib/cue_sync.awk so the
         # test runner (.just/lib/cue_sync_test.sh) invokes the exact same

--- a/.just/gh-process.just
+++ b/.just/gh-process.just
@@ -13,7 +13,7 @@ sync:
     git pull
     git status --porcelain # stp
 
-# PR create v8.0
+# PR create v8.1
 [group('Process')]
 pr: _has_commits && pr_checks
     #!/usr/bin/env bash

--- a/.just/lib/cue_sync.awk
+++ b/.just/lib/cue_sync.awk
@@ -5,9 +5,15 @@
 # file guarantees both callers run identical awk logic; a change here is
 # automatically exercised by both paths. See issue #196.
 #
-# Variables expected from -v:
-#   desc   - escaped description string (quotes already backslashed)
-#   topics - TOML topics array literal, e.g. ["a", "b"]
+# Inputs:
+#   ENVIRON["desc"]   - raw description string (no -v escape processing)
+#   -v topics         - TOML topics array literal, e.g. ["a", "b"]
+#
+# Description is read from the environment (not -v) because awk's -v flag
+# processes backslash escape sequences before the program runs, which would
+# mangle backslashes in the GitHub description. See issue #198. TOML-escaping
+# of backslashes and double-quotes is applied on emit by toml_escape(), so
+# the produced line is valid TOML regardless of the description's contents.
 #
 # State-aware: handles three cases for each key (description, topics):
 #   1. Active line (e.g. `topics = [...]`)        -> replace in place
@@ -24,11 +30,13 @@
 # Missing keys are flushed either when the next `[section]` begins or at
 # EOF (END block), preserving the original field order of any other keys
 # in [about]. See issue #165 for the failure modes this addresses.
+function toml_escape(s) { gsub(/\\/, "\\\\", s); gsub(/"/, "\\\"", s); return s }
+function desc_line()    { return "description = \"" toml_escape(ENVIRON["desc"]) "\"" }
 function flush_blanks() { if (blanks != "") { printf "%s", blanks; blanks="" } }
 /^\[about\]/ { in_about=1; flush_blanks(); print; next }
 /^\[/ && !/^\[about\]/ {
 	if (in_about) {
-		if (!desc_written)   { print "description = \"" desc "\""; desc_written=1 }
+		if (!desc_written)   { print desc_line(); desc_written=1 }
 		if (!topics_written) { print "topics = " topics; topics_written=1 }
 	}
 	in_about=0
@@ -36,13 +44,13 @@ function flush_blanks() { if (blanks != "") { printf "%s", blanks; blanks="" } }
 	print
 	next
 }
-in_about && /^[#[:space:]]*description[[:space:]]*=/ { flush_blanks(); print "description = \"" desc "\""; desc_written=1; next }
+in_about && /^[#[:space:]]*description[[:space:]]*=/ { flush_blanks(); print desc_line(); desc_written=1; next }
 in_about && /^[#[:space:]]*topics[[:space:]]*=/      { flush_blanks(); print "topics = " topics; topics_written=1; next }
 in_about && /^[[:space:]]*$/ { blanks=blanks "\n"; next }
 { flush_blanks(); print }
 END {
 	if (in_about) {
-		if (!desc_written)   { print "description = \"" desc "\""; desc_written=1 }
+		if (!desc_written)   { print desc_line(); desc_written=1 }
 		if (!topics_written) { print "topics = " topics; topics_written=1 }
 	}
 	flush_blanks()

--- a/.just/lib/cue_sync_test.sh
+++ b/.just/lib/cue_sync_test.sh
@@ -30,13 +30,11 @@ failed=0
 
 run_awk() {
 	local input="$1" desc="$2" topics="$3"
-	# Mirror the escape step performed by the cue-sync-from-github recipe
-	# (.just/cue-verify.just): awk's -v assignment processes backslash escape
-	# sequences before the program runs, so backslashes must be double-escaped
-	# first, then double-quotes escaped for TOML. See issue #198.
-	local escaped="${desc//\\/\\\\}"
-	escaped="${escaped//\"/\\\"}"
-	awk -v desc="$escaped" -v topics="[$topics]" -f "$AWK_PROGRAM" "$input"
+	# Pass description via the environment (desc=...), not awk's -v, because
+	# -v processes backslash escape sequences before the program runs. The
+	# awk program applies TOML-escaping on emit, so callers pass the raw
+	# description unmodified. See issue #198.
+	desc="$desc" awk -v topics="[$topics]" -f "$AWK_PROGRAM" "$input"
 }
 
 # Assert helpers - count failures via a global flag
@@ -180,15 +178,17 @@ main() {
 		'topics = \[[^]]*\]' "topics = [$topics]" \
 		"active topics replaced inside [about]"
 
-	# Case 6: backslashes in description must be preserved through the awk -v
-	# handoff. awk's -v assignment processes backslash escape sequences
-	# (\n, \t, \p -> p) before the program runs, so a description like
-	# "C:\path\to\thing" would be silently mangled to "C:athothing" unless
-	# the recipe double-escapes backslashes before invoking awk. See #198.
+	# Case 6: backslashes in description must survive the sync and produce
+	# valid TOML. The description is passed raw via the environment; the awk
+	# program TOML-escapes backslashes (-> \\) and double-quotes (-> \") on
+	# emit. Asserting the escaped form verifies both that -v mangling is
+	# avoided (would have lost backslashes entirely) and that the output is
+	# valid TOML (a raw `\p` would fail cue vet). See #198.
 	local bs_desc='C:\path\to\thing'
+	local bs_desc_toml='C:\\path\\to\\thing'
 	run_test "active_keys.toml" "$bs_desc" "$topics" \
-		'description = "[^"]*"' "description = \"$bs_desc\"" \
-		"backslashes in description preserved through awk -v (issue #198)"
+		'description = "[^"]*"' "description = \"$bs_desc_toml\"" \
+		"backslashes in description preserved and TOML-escaped (issue #198)"
 
 	echo
 	echo -e "Results: ${GREEN}$passed passed${NORMAL}, ${RED}$failed failed${NORMAL}"

--- a/.just/lib/cue_sync_test.sh
+++ b/.just/lib/cue_sync_test.sh
@@ -30,7 +30,13 @@ failed=0
 
 run_awk() {
 	local input="$1" desc="$2" topics="$3"
-	awk -v desc="$desc" -v topics="[$topics]" -f "$AWK_PROGRAM" "$input"
+	# Mirror the escape step performed by the cue-sync-from-github recipe
+	# (.just/cue-verify.just): awk's -v assignment processes backslash escape
+	# sequences before the program runs, so backslashes must be double-escaped
+	# first, then double-quotes escaped for TOML. See issue #198.
+	local escaped="${desc//\\/\\\\}"
+	escaped="${escaped//\"/\\\"}"
+	awk -v desc="$escaped" -v topics="[$topics]" -f "$AWK_PROGRAM" "$input"
 }
 
 # Assert helpers - count failures via a global flag
@@ -173,6 +179,16 @@ main() {
 	run_test "active_keys.toml" "$desc" "$topics" \
 		'topics = \[[^]]*\]' "topics = [$topics]" \
 		"active topics replaced inside [about]"
+
+	# Case 6: backslashes in description must be preserved through the awk -v
+	# handoff. awk's -v assignment processes backslash escape sequences
+	# (\n, \t, \p -> p) before the program runs, so a description like
+	# "C:\path\to\thing" would be silently mangled to "C:athothing" unless
+	# the recipe double-escapes backslashes before invoking awk. See #198.
+	local bs_desc='C:\path\to\thing'
+	run_test "active_keys.toml" "$bs_desc" "$topics" \
+		'description = "[^"]*"' "description = \"$bs_desc\"" \
+		"backslashes in description preserved through awk -v (issue #198)"
 
 	echo
 	echo -e "Results: ${GREEN}$passed passed${NORMAL}, ${RED}$failed failed${NORMAL}"


### PR DESCRIPTION
Fixes #196 

<!-- PR_BODY_DONE_START -->
## Done

- 🩹 [just] gh-process v8.1 fix awk backslash mangling in cue-sync
- 🔁 [just] regenerate CHECKSUMS.json for v8.1
- refactor to improve resilience
- regenerate checksums

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
